### PR TITLE
实现 warppartyrevive 脚本指令, 与 warpparty 类似, 但可以复活死亡的队友并传送

### DIFF
--- a/doc/pandas_script_commands.txt
+++ b/doc/pandas_script_commands.txt
@@ -588,3 +588,18 @@ IP地址:
 
 返回值:
 	出错返回 -1, 其他含 0 正整数表示查到的此 IP 的在线玩家数
+
+---------------------------------------
+
+*warppartyrevive "<to_mapname>",<x>,<y>,<party_id>,{"<from_mapname>",<range x>,<range y>};
+*warpparty2 "<to_mapname>",<x>,<y>,<party_id>,{"<from_mapname>",<range x>,<range y>};
+
+该指令的用法与 warpparty 完全一样, 都是将指定队伍全员传送到指定目的地.
+
+区别在于: 
+	warpparty 对已经死亡的队友则无效 (死亡的队友会被留在原地),
+	warppartyrevive 对已经死亡的队友有效 (队友会被立刻复活, 并一起被传送走).
+
+返回值:
+	该指令无论成功失败, 都不会有返回值
+

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -324,6 +324,10 @@
 	// 是否启用 getsameipinfo 脚本指令 [Sola丶小克]
 	// 获得某个指定 IP 在线的玩家信息
 	#define Pandas_ScriptCommand_GetSameIpInfo
+
+	// 是否启用 warppartyrevive 脚本指令 [Sola丶小克]
+	// 与 warpparty 类似, 但可以复活死亡的队友并传送 (该指令有一个用于兼容的别名: warpparty2)
+	#define Pandas_ScriptCommand_WarpPartyRevive
 	// PYHELP - SCRIPTCMD - INSERT POINT - <Section 1>
 #endif // Pandas_ScriptCommands
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -5643,8 +5643,14 @@ BUILDIN_FUNC(warpparty)
 		if( str2 && strcmp(str2, map_getmapdata(pl_sd->bl.m)->name) != 0 )
 			continue;
 
+#ifndef Pandas_ScriptCommand_WarpPartyRevive
 		if( pc_isdead(pl_sd) )
 			continue;
+#else
+		// 若使用的为 warppartyrevive 指令名, 那么死亡的队员也不会被忽略
+		if (pc_isdead(pl_sd) && strcmpi(script_getfuncname(st), "warppartyrevive") != 0 && strcmpi(script_getfuncname(st), "warpparty2") != 0)
+			continue;
+#endif // Pandas_ScriptCommand_WarpPartyRevive
 
 		switch( type )
 		{
@@ -25444,6 +25450,10 @@ struct script_function buildin_func[] = {
 #ifdef Pandas_ScriptCommand_GetSameIpInfo
 	BUILDIN_DEF(getsameipinfo,"?"),						// 获得某个指定 IP 在线的玩家信息 [Sola丶小克]
 #endif // Pandas_ScriptCommand_GetSameIpInfo
+#ifdef Pandas_ScriptCommand_WarpPartyRevive
+	BUILDIN_DEF2(warpparty,"warppartyrevive","siii???"),// 与 warpparty 类似, 但可以复活死亡的队友并传送 [Sola丶小克]
+	BUILDIN_DEF2(warpparty,"warpparty2","siii???"),		// 指定一个别名, 以便兼容的老版本或其他服务端
+#endif // Pandas_ScriptCommand_WarpPartyRevive
 	// PYHELP - SCRIPTCMD - INSERT POINT - <Section 3>
 	// NPC interaction
 	BUILDIN_DEF(mes,"s*"),


### PR DESCRIPTION
*warppartyrevive "<to_mapname>",<x>,<y>,<party_id>,{"<from_mapname>",<range x>,<range y>};
*warpparty2 "<to_mapname>",<x>,<y>,<party_id>,{"<from_mapname>",<range x>,<range y>};

该指令的用法与 warpparty 完全一样, 都是将指定队伍全员传送到指定目的地.

区别在于: 
	warpparty 对已经死亡的队友则无效 (死亡的队友会被留在原地),
	warppartyrevive 对已经死亡的队友有效 (队友会被立刻复活, 并一起被传送走).

返回值:
	该指令无论成功失败, 都不会有返回值