### PR TITLE
实现 logout 脚本指令, 用于使指定的角色立刻登出游戏

### DIFF
--- a/doc/pandas_script_commands.txt
+++ b/doc/pandas_script_commands.txt
@@ -588,3 +588,41 @@ IP地址:
 
 返回值:
 	出错返回 -1, 其他含 0 正整数表示查到的此 IP 的在线玩家数
+
+---------------------------------------
+
+*logout <登出理由>{,"<角色名称>"|<账号编号>|<角色编号>};
+
+使指定的角色立刻登出游戏(踢下线), 此处的"登出理由"只能做参考,
+不同的理由编号会让客户端给玩家显示不同的 msgstringtable 提示文本:
+
+登出理由:
+	0 = BAN_UNFAIR
+	1 = 服务器已关闭 -> MsgStringTable[4]
+	2 = ID already logged in -> MsgStringTable[5]
+	3 = 连接超时 / 网络延迟不稳定 -> MsgStringTable[241]
+	4 = 服务器已经满员 -> MsgStringTable[264]
+	5 = underaged -> MsgStringTable[305]
+	8 = Server sill recognizes last connection -> MsgStringTable[441]
+	9 = too many connections from this ip -> MsgStringTable[529]
+	10 = out of available time paid for -> MsgStringTable[530]
+	11 = BAN_PAY_SUSPEND
+	12 = BAN_PAY_CHANGE
+	13 = BAN_PAY_WRONGIP
+	14 = BAN_PAY_PNGAMEROOM
+	15 = 被 GM 踢下线 -> if( servicetype == taiwan ) MsgStringTable[579]
+	16 = BAN_JAPAN_REFUSE1
+	17 = BAN_JAPAN_REFUSE2
+	18 = BAN_INFORMATION_REMAINED_ANOTHER_ACCOUNT
+	100 = BAN_PC_IP_UNFAIR
+	101 = BAN_PC_IP_COUNT_ALL
+	102 = BAN_PC_IP_COUNT
+	103 = BAN_GRAVITY_MEM_AGREE
+	104 = BAN_GAME_MEM_AGREE
+	105 = BAN_HAN_VALID
+	106 = BAN_PC_IP_LIMIT_ACCESS
+	107 = BAN_OVER_CHARACTER_LIST
+	108 = BAN_IP_BLOCK
+	109 = BAN_INVALID_PWD_CNT
+	110 = BAN_NOT_ALLOWED_JOBCLASS
+	111 = 与服务器断开连接 -> MsgStringTable[3]

--- a/doc/pandas_script_commands.txt
+++ b/doc/pandas_script_commands.txt
@@ -626,3 +626,6 @@ IP地址:
 	109 = BAN_INVALID_PWD_CNT
 	110 = BAN_NOT_ALLOWED_JOBCLASS
 	111 = 与服务器断开连接 -> MsgStringTable[3]
+
+返回值:
+	该指令无论成功失败, 都不会有返回值

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -324,6 +324,10 @@
 	// 是否启用 getsameipinfo 脚本指令 [Sola丶小克]
 	// 获得某个指定 IP 在线的玩家信息
 	#define Pandas_ScriptCommand_GetSameIpInfo
+
+	// 是否启用 logout 脚本指令 [Sola丶小克]
+	// 使指定的角色立刻登出游戏
+	#define Pandas_ScriptCommand_Logout
 	// PYHELP - SCRIPTCMD - INSERT POINT - <Section 1>
 #endif // Pandas_ScriptCommands
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -25338,6 +25338,48 @@ BUILDIN_FUNC(getsameipinfo) {
 }
 #endif // Pandas_ScriptCommand_GetSameIpInfo
 
+#ifdef Pandas_ScriptCommand_Logout
+/* ===========================================================
+ * 指令: logout
+ * 描述: 使指定的角色立刻登出游戏
+ * 用法: logout <登出理由>{,"<角色名称>"|<账号编号>|<角色编号>};
+ * 返回: 该指令无论成功失败, 都不会有返回值
+ * 作者: Sola丶小克
+ * -----------------------------------------------------------*/
+BUILDIN_FUNC(logout) {
+	struct map_session_data *sd = nullptr;
+	int reason = script_getnum(st, 2);
+
+	if (script_hasdata(st, 3))
+	{
+		if (script_isstring(st, 3))
+			sd = map_nick2sd(script_getstr(st, 3), false);
+		else
+		{
+			int id = script_getnum(st, 3);
+
+			sd = (map_id2sd(id) ? map_id2sd(id) : map_charid2sd(id));
+		}
+	}
+	else
+		script_rid2sd(sd);
+
+	if (!sd)
+		return SCRIPT_CMD_SUCCESS;
+
+	if (!((reason >= 0 && reason <= 18) || (reason >= 100 && reason <= 110) || reason == 111)) {
+		ShowWarning("buildin_logout: unknown logout reason %d\n", reason);
+		return SCRIPT_CMD_SUCCESS;
+	}
+
+	if (sd->fd)
+		clif_authfail_fd(sd->fd, reason);
+	else
+		map_quit(sd);
+	return SCRIPT_CMD_SUCCESS;
+}
+#endif // Pandas_ScriptCommand_Logout
+
 // PYHELP - SCRIPTCMD - INSERT POINT - <Section 2>
 
 /// script command definitions
@@ -25444,6 +25486,9 @@ struct script_function buildin_func[] = {
 #ifdef Pandas_ScriptCommand_GetSameIpInfo
 	BUILDIN_DEF(getsameipinfo,"?"),						// 获得某个指定 IP 在线的玩家信息 [Sola丶小克]
 #endif // Pandas_ScriptCommand_GetSameIpInfo
+#ifdef Pandas_ScriptCommand_Logout
+	BUILDIN_DEF(logout,"i?"),							// 使指定的角色立刻登出游戏 [Sola丶小克]
+#endif // Pandas_ScriptCommand_Logout
 	// PYHELP - SCRIPTCMD - INSERT POINT - <Section 3>
 	// NPC interaction
 	BUILDIN_DEF(mes,"s*"),


### PR DESCRIPTION
*logout <登出理由>{,"<角色名称>"|<账号编号>|<角色编号>};

使指定的角色立刻登出游戏(踢下线), 此处的"登出理由"只能做参考,
不同的理由编号会让客户端给玩家显示不同的 msgstringtable 提示文本:

登出理由:
	0 = BAN_UNFAIR
	1 = 服务器已关闭 -> MsgStringTable[4]
	2 = ID already logged in -> MsgStringTable[5]
	3 = 连接超时 / 网络延迟不稳定 -> MsgStringTable[241]
	4 = 服务器已经满员 -> MsgStringTable[264]
	5 = underaged -> MsgStringTable[305]
	8 = Server sill recognizes last connection -> MsgStringTable[441]
	9 = too many connections from this ip -> MsgStringTable[529]
	10 = out of available time paid for -> MsgStringTable[530]
	11 = BAN_PAY_SUSPEND
	12 = BAN_PAY_CHANGE
	13 = BAN_PAY_WRONGIP
	14 = BAN_PAY_PNGAMEROOM
	15 = 被 GM 踢下线 -> if( servicetype == taiwan ) MsgStringTable[579]
	16 = BAN_JAPAN_REFUSE1
	17 = BAN_JAPAN_REFUSE2
	18 = BAN_INFORMATION_REMAINED_ANOTHER_ACCOUNT
	100 = BAN_PC_IP_UNFAIR
	101 = BAN_PC_IP_COUNT_ALL
	102 = BAN_PC_IP_COUNT
	103 = BAN_GRAVITY_MEM_AGREE
	104 = BAN_GAME_MEM_AGREE
	105 = BAN_HAN_VALID
	106 = BAN_PC_IP_LIMIT_ACCESS
	107 = BAN_OVER_CHARACTER_LIST
	108 = BAN_IP_BLOCK
	109 = BAN_INVALID_PWD_CNT
	110 = BAN_NOT_ALLOWED_JOBCLASS
	111 = 与服务器断开连接 -> MsgStringTable[3]

返回值:
	该指令无论成功失败, 都不会有返回值