### PR TITLE
修正 reloadnpc 时文件路径前后有空格所带来的不良影响

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -226,6 +226,10 @@
 	// 修正使用 pointshop 类型的商店操作 #CASHPOINTS 或 #KAFRAPOINTS 变量完成最终的货币结算后
 	// 小地图旁边的"道具商城"按钮中的金额不被更新, 最终导致双花的问题 [Sola丶小克]
 	#define Pandas_Fix_PointShop_Double_Spend_Attack
+
+	// 修正 npc_unloadfile 和 npc_parsesrcfile 的行为会被空格影响的问题 [Sola丶小克]
+	// 如果 @reloadnpc 时给定的路径带空格, 系统将无法正确的 unloadnpc, 导致 npc 重复出现
+	#define Pandas_Fix_NPC_Filepath_WhiteSpace_Effects
 #endif // Pandas_Bugfix
 
 // ============================================================================

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -4446,6 +4446,10 @@ int npc_parsesrcfile(const char* filepath, bool runOnInit)
 	char* buffer;
 	const char* p;
 
+#ifdef Pandas_Fix_NPC_Filepath_WhiteSpace_Effects
+	trim((char*)filepath);
+#endif // Pandas_Fix_NPC_Filepath_WhiteSpace_Effects
+
 	if(check_filepath(filepath)!=2) { //this is not a file 
 		ShowDebug("npc_parsesrcfile: Path doesn't seem to be a file skipping it : '%s'.\n", filepath);
 		return 0;
@@ -4953,6 +4957,10 @@ bool npc_unloadfile( const char* path ) {
 	DBIterator * iter = db_iterator(npcname_db);
 	struct npc_data* nd = NULL;
 	bool found = false;
+
+#ifdef Pandas_Fix_NPC_Filepath_WhiteSpace_Effects
+	trim((char*)path);
+#endif // Pandas_Fix_NPC_Filepath_WhiteSpace_Effects
 
 	for( nd = (struct npc_data*)dbi_first(iter); dbi_exists(iter); nd = (struct npc_data*)dbi_next(iter) ) {
 		if( nd->path && strcasecmp(nd->path,path) == 0 ) {


### PR DESCRIPTION
本提交用于解决 #132 中提及的问题