### PR TITLE
使用 vector 作为 stack 的容器 (感谢 kkk 的反馈)

### DIFF
--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -26,7 +26,7 @@
 #endif // Pandas_Struct_Map_Session_Data_WorkInEvent
 
 #ifdef Pandas_ScriptEngine_MutliStackBackup
-#include <stack>
+#include <stack> // std::stack
 #endif // Pandas_ScriptEngine_MutliStackBackup
 
 enum AtCommandType : uint8;
@@ -365,7 +365,7 @@ struct map_session_data {
 	int npc_amount;
 	struct script_state *st;
 #ifdef Pandas_ScriptEngine_MutliStackBackup
-	std::stack<mutli_script_state> mbk_st;
+	std::stack<mutli_state, std::vector<mutli_state>> mbk_st;
 #endif // Pandas_ScriptEngine_MutliStackBackup
 	char npc_str[CHATBOX_SIZE]; // for passing npc input box text to script engine
 	int npc_timer_id; //For player attached npc timers. [Skotlex]

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -4371,7 +4371,7 @@ void script_detach_state(struct script_state* st, bool dequeue_event)
 		sd->state.disable_atcommand_on_npc = 0;
 
 		if (!sd->mbk_st.empty()) {
-			struct mutli_script_state val = sd->mbk_st.top();
+			struct mutli_state val = sd->mbk_st.top();
 			sd->st = val.bk_st;
 			sd->npc_id = val.bk_npcid;
 			sd->mbk_st.pop();
@@ -4411,7 +4411,7 @@ void script_attach_state(struct script_state* st){
 			st->bk_st = sd->st;
 			st->bk_npcid = sd->npc_id;
 #else
-			struct mutli_script_state mbk_st = { 0 };
+			struct mutli_state mbk_st = { 0 };
 			mbk_st.bk_st = sd->st;
 			mbk_st.bk_npcid = sd->npc_id;
 			sd->mbk_st.push(mbk_st);

--- a/src/map/script.hpp
+++ b/src/map/script.hpp
@@ -393,7 +393,7 @@ struct script_state {
 };
 
 #ifdef Pandas_ScriptEngine_MutliStackBackup
-struct mutli_script_state {
+struct mutli_state {
 	struct script_state* bk_st;
 	int bk_npcid;
 };

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3243,7 +3243,7 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 
 #ifdef Pandas_ScriptEngine_MutliStackBackup
 			while (!sd->mbk_st.empty()) {
-				struct mutli_script_state val = sd->mbk_st.top();
+				struct mutli_state val = sd->mbk_st.top();
 				if (val.bk_st != nullptr) {
 					script_free_state(sd->mbk_st.top().bk_st);
 				}


### PR DESCRIPTION
以此规避在 VS2017 下调用 top 方法导致地图服务器崩溃的问题