### PR TITLE
修正启用多层脚本堆栈后会导致 doevent 表现异常的问题

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -4411,10 +4411,12 @@ void script_attach_state(struct script_state* st){
 			st->bk_st = sd->st;
 			st->bk_npcid = sd->npc_id;
 #else
-			struct mutli_state mbk_st = { 0 };
-			mbk_st.bk_st = sd->st;
-			mbk_st.bk_npcid = sd->npc_id;
-			sd->mbk_st.push(mbk_st);
+			if (sd->st) {
+				struct mutli_state mbk_st = { 0 };
+				mbk_st.bk_st = sd->st;
+				mbk_st.bk_npcid = sd->npc_id;
+				sd->mbk_st.push(mbk_st);
+			}
 #endif // Pandas_ScriptEngine_MutliStackBackup
 		}
 		sd->st = st;


### PR DESCRIPTION
## 测试脚本

```
prontera,150,150,5	script	NPC_MES	53,{
	mes "这是第一次, 即将触发 NPC_MES_1::OnLabel";
	mes "后续弹出应该都是有 mes 对话框的.";
	doevent "NPC_MES_1::OnLabel";
	close;
}

-	script	NPC_MES_1	53,{
end;
OnLabel:
	mes "这是第二次, 即将触发 NPC_MES_2::OnLabel";
	doevent "NPC_MES_2::OnLabel";
	close;
}

-	script	NPC_MES_2	53,{
end;
OnLabel:
	mes "这是第三次, 即将触发 NPC_MES_3::OnLabel";
	doevent "NPC_MES_3::OnLabel";
	close;
}

-	script	NPC_MES_3	53,{
end;
OnLabel:
	mes "这是第四次, 流程结束";
	close;
}

prontera,156,150,5	script	NPC_DISP	53,{
	mes "这是第一次, 即将触发 NPC_DISP_1::OnLabel";
	mes "后续行为只会在聊天窗口显示信息.";
	doevent "NPC_DISP_1::OnLabel";
	close;
}

-	script	NPC_DISP_1	53,{
end;
OnLabel:
	dispbottom "这是第二次, 即将触发 NPC_DISP_2::OnLabel";
	doevent "NPC_DISP_2::OnLabel";
}

-	script	NPC_DISP_2	53,{
end;
OnLabel:
	dispbottom "这是第三次, 即将触发 NPC_DISP_3::OnLabel";
	doevent "NPC_DISP_3::OnLabel";
}

-	script	NPC_DISP_3	53,{
end;
OnLabel:
	dispbottom "这是第四次, 流程结束";
}


prontera,153,150,5	script	NPCEACH	53,{
	script4each "{ getitem 505, 1; }",0;
}

```