### PR TITLE
修正在部分 CPU 上运行 VS2019 16.3 编译出来的程序会崩溃的问题

### DIFF
--- a/src/common/assistant.cpp
+++ b/src/common/assistant.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <fstream>
 #include <cctype> // std::tolower std::toupper std::isspace
+#include <stdio.h> // __isa_available
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -36,6 +37,8 @@
 #else
 	const std::string pathSep = "/";
 #endif // _WIN32
+
+extern "C" int __isa_available;
 
 //************************************
 // Method:      deployImportDirectory
@@ -760,4 +763,19 @@ bool isIndependentBackslash(const char* p) {
 
 	// 其他不认识的情况, 将其当做一个非独立字符的反斜杠处理, 返回 false
 	return false;
+}
+
+//************************************
+// Method:      correct_isa_available
+// Description: 修正在支持 AVX512 指令的设备上
+//              使用 std::unordered_map::reserve 会提示 Illegal instruction 的问题
+// Returns:     void
+// Author:      Sola丶小克(CairoLee)  2019/11/17 23:28
+//************************************
+void correct_isa_available() {
+#if (_MSC_VER == 1923)	// Visual Studio 2019 version 16.3
+	if (__isa_available > 5) {
+		__isa_available = 5;
+	}
+#endif // (_MSC_VER == 1923)
 }

--- a/src/common/assistant.hpp
+++ b/src/common/assistant.hpp
@@ -57,3 +57,5 @@ std::string getSystemLanguage();
 std::string getPandasVersion(bool bPrefix = true, bool bSuffix = true);
 
 bool isIndependentBackslash(const char* p);
+
+void correct_isa_available();

--- a/src/common/core.cpp
+++ b/src/common/core.cpp
@@ -373,6 +373,10 @@ void usercheck(void)
  *--------------------------------------*/
 int main (int argc, char **argv)
 {
+#ifdef Pandas_Crashfix_VisualStudio_UnorderedMap_AVX512
+	correct_isa_available();
+#endif // Pandas_Crashfix_VisualStudio_UnorderedMap_AVX512
+
 #ifdef Pandas_Google_Breakpad
 	breakpad_initialize();
 #endif // Pandas_Google_Breakpad

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -330,6 +330,18 @@
 	// 重现方法:
 	// 使 NPC 调用 .@result = inarray(getd(" $test"), 100); 即可触发崩溃
 	#define Pandas_Crashfix_ScriptCommand_Getd_And_Setd
+
+	// 修正 Visual Studio 2019 的 16.3 在支持 AVX512 指令集的设备上
+	// 使用 std::unordered_map::reserve 会提示 Illegal instruction 并导致地图服务器崩溃的问题.
+	// 
+	// 虽然根据微软的回复已经在 Visual Studio 2019 的 16.4 Preview 4 中解决了问题,
+	// 考虑部分用户可能会一直停留在存在问题的编译器上工作, 因此做一个热修复.
+	//
+	// 此修复只对 _MSC_VER == 1923 的 Visual Studio 编译器有效 (对应 Visual Studio 2019 16.3 版本)
+	// https://developercommunity.visualstudio.com/content/problem/787296/vs2019-163-seems-to-incorrectly-detect-avx512-on-w.html
+	//
+	// 感谢"李小狼"在阿里云服务器上暴露此问题, 并提供调试环境
+	#define Pandas_Crashfix_VisualStudio_UnorderedMap_AVX512
 #endif // Pandas_Crashfix
 
 // ============================================================================


### PR DESCRIPTION
修正 Visual Studio 2019 的 16.3 在支持 AVX512 指令集的设备上
使用 std::unordered_map::reserve 会提示 Illegal instruction 并导致地图服务器崩溃的问题.

虽然根据微软的回复已经在 Visual Studio 2019 的 16.4 Preview 4 中解决了问题,
考虑部分用户可能会一直停留在存在问题的编译器上工作, 因此做一个热修复.

此修复只对 _MSC_VER == 1923 的 Visual Studio 编译器有效 (对应 Visual Studio 2019 16.3 版本)
https://developercommunity.visualstudio.com/content/problem/787296/vs2019-163-seems-to-incorrectly-detect-avx512-on-w.html

感谢"李小狼"在阿里云服务器上暴露此问题, 并提供调试环境