### PR TITLE
修正在 NPC 事件脚本代码中执行 unloadnpc 会导致地图服务器崩溃的问题

### DIFF
--- a/doc/pandas_script_commands.txt
+++ b/doc/pandas_script_commands.txt
@@ -932,7 +932,7 @@ IP地址:
 	举例说明:
 		假设有以下 NPC 我们想把它复制一个新的出来:
 
-			prontera,146,99,2    script    PVP管理员::PVPCOPYTEST    123,{
+			prontera,146,99,2	script	PVP管理员::PVPCOPYTEST	123,{
 				mes "[PVP管理员]";
 				mes "场地正在修理, 请稍后再来...";
 				close;

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -342,6 +342,14 @@
 	//
 	// 感谢"李小狼"在阿里云服务器上暴露此问题, 并提供调试环境
 	#define Pandas_Crashfix_VisualStudio_UnorderedMap_AVX512
+
+	// 修正在 NPC 事件脚本代码中执行 unloadnpc 会导致地图服务器崩溃的问题 [Sola丶小克]
+	// unloadnpc 的时候会重新构造 script_event 这个 std::map 的内容
+	// 这会导致 npc_script_event 中提前获取的 vector 引用所指向的内容被清空,
+	// 以至于在执行下一轮循环的时候, 无法获取已经被清空的原 script_event 内容, 而触发崩溃
+	//
+	// 感谢"聽風"指出重现此问题的条件和环境
+	#define Pandas_Crashfix_Unloadnpc_In_Event
 #endif // Pandas_Crashfix
 
 // ============================================================================

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -4716,7 +4716,13 @@ int npc_script_event(struct map_session_data* sd, enum npce_event type){
 		return 0;
 #endif // Pandas_Struct_Map_Session_Data_EventTrigger
 
+#ifndef Pandas_Crashfix_Unloadnpc_In_Event
 	std::vector<struct script_event_s>& vector = script_event[type];
+#else
+	// 这里不能取引用, 因为执行脚本事件的时候若触发 unloadnpc 指令,
+	// 那么 unloadnpc 内部会重置 script_event 的值, 导致引用指向的内容变得不可信任
+	std::vector<struct script_event_s> vector = script_event[type];
+#endif // Pandas_Crashfix_Unloadnpc_In_Event
 
 	for( struct script_event_s& evt : vector ){
 #ifdef Pandas_ScriptEngine_Express


### PR DESCRIPTION
修正在 NPC 事件脚本代码中执行 unloadnpc 会导致地图服务器崩溃的问题 [Sola丶小克]
unloadnpc 的时候会重新构造 script_event 这个 std::map 的内容
这会导致 npc_script_event 中提前获取的 vector 引用所指向的内容被清空,
以至于在执行下一轮循环的时候, 无法获取已经被清空的原 script_event 内容, 而触发崩溃

感谢"聽風"指出重现此问题的条件和环境

此问题是在实现 #183 提到的需求时，顺便定位到的