### PR TITLE
使战斗配置选项可限制玩家在 PVP 地图上的最大攻速

### DIFF
--- a/conf/battle/pandas.conf
+++ b/conf/battle/pandas.conf
@@ -56,4 +56,18 @@ force_identified: 0
 // rAthena 默认禁止在坐骑的时候使用“延迟消耗类物品”, 因此该选项的默认值为 64
 cashmount_useitem_limit: 64
 
+// 玩家在 PVP 地图上的最大攻速限制 (全职业限制)
+//
+// 若玩家根据 conf/player.conf 的 max_aspd、max_third_aspd、
+// max_extended_aspd 计算出来的最大攻速, 比此选项设置的值更加小,
+// 则以更小的攻速限制为准.
+// 
+// 假设此选项设置为 191, 且 conf/player.conf 的 max_aspd 为 190 的话
+// 若你的职业是个剑士, 且处于 PVP 地图, 那么你的最大攻速将是 190,
+// 而不是此选项设置的 191 (因为 max_aspd 的限制 190 更小)
+//
+// 若一张地图同时启用了 PVP 和 GVG 的话, 则以 GVG 的攻速限制优先
+// 若设置为 0 则关闭此限制, 最大值可填写 199
+max_aspd_for_pvp: 0
+
 // PYHELP - BATTLECONFIG - INSERT POINT - <Section 4>

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -177,6 +177,10 @@
 	// 是否启用 cashmount_useitem_limit 配置选项及其功能 [Sola丶小克]
 	// 此选项可以使乘坐“商城坐骑”时禁止使用特定类型的物品
 	#define Pandas_BattleConfig_CashMounting_UseitemLimit
+
+	// 是否启用 max_aspd_for_pvp 配置选项及其功能 [Sola丶小克]
+	// 此选项用于限制玩家在 PVP 地图上的最大攻击速度 (以 MF_PVP 地图标记为准)
+	#define Pandas_BattleConfig_MaxAspdForPVP
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 1>
 #endif // Pandas_BattleConfigure
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8685,6 +8685,9 @@ static const struct _battle_data {
 #ifdef Pandas_BattleConfig_CashMounting_UseitemLimit
 	{ "cashmount_useitem_limit",            &battle_config.cashmount_useitem_limit,         64,     0,      511,            },
 #endif // Pandas_BattleConfig_CashMounting_UseitemLimit
+#ifdef Pandas_BattleConfig_MaxAspdForPVP
+	{ "max_aspd_for_pvp",                   &battle_config.max_aspd_for_pvp,                0,      0,      199,            },
+#endif // Pandas_BattleConfig_MaxAspdForPVP
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 3>
 #include "../custom/battle_config_init.inc"
 };
@@ -8765,6 +8768,13 @@ void battle_adjust_conf()
 	battle_config.max_extended_aspd = 2000 - battle_config.max_extended_aspd * 10;
 	battle_config.max_walk_speed = 100 * DEFAULT_WALK_SPEED / battle_config.max_walk_speed;
 	battle_config.max_cart_weight *= 10;
+
+#ifdef Pandas_BattleConfig_MaxAspdForPVP
+	// 根据 max_aspd_for_pvp 约束玩家的最大攻速 [Sola丶小克]
+	// 这里对配置的 ASPD 数值 (例如: 193, 197) 转换成程序判断用的攻速数值
+	if (battle_config.max_aspd_for_pvp > 0)
+		battle_config.max_aspd_for_pvp = 2000 - battle_config.max_aspd_for_pvp * 10;
+#endif // Pandas_BattleConfig_MaxAspdForPVP
 
 	if (battle_config.max_def > 100 && !battle_config.weapon_defense_type) // added by [Skotlex]
 		battle_config.max_def = 100;

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -675,14 +675,17 @@ struct Battle_Config
 
 	// Pandas Configure
 #ifdef Pandas_BattleConfig_Force_LoadEvent
-	int force_loadevent;		// 强制触发 OnPCLoadMapEvent 事件 [Sola丶小克]
+	int force_loadevent; // 强制触发 OnPCLoadMapEvent 事件 [Sola丶小克]
 #endif // Pandas_BattleConfig_Force_LoadEvent
 #ifdef Pandas_BattleConfig_Force_Identified
-	int force_identified;		// 强制特定渠道获得的装备自动变成已鉴定 [Sola丶小克]
+	int force_identified; // 强制特定渠道获得的装备自动变成已鉴定 [Sola丶小克]
 #endif // Pandas_BattleConfig_Force_Identified
 #ifdef Pandas_BattleConfig_CashMounting_UseitemLimit
-	int cashmount_useitem_limit;	// 乘坐“商城坐骑”时禁止使用特定类型的物品 [Sola丶小克]
+	int cashmount_useitem_limit; // 乘坐“商城坐骑”时禁止使用特定类型的物品 [Sola丶小克]
 #endif // Pandas_BattleConfig_CashMounting_UseitemLimit
+#ifdef Pandas_BattleConfig_MaxAspdForPVP
+	int max_aspd_for_pvp; // 限制玩家在 PVP 时的最大攻速 [Sola丶小克]
+#endif // Pandas_BattleConfig_MaxAspdForPVP
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 2>
 
 #include "../custom/battle_config_struct.inc"

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -4604,6 +4604,13 @@ static int map_mapflag_pvp_start_sub(struct block_list *bl, va_list ap)
 	}
 
 	clif_map_property(&sd->bl, MAPPROPERTY_FREEPVPZONE, SELF);
+
+#ifdef Pandas_BattleConfig_MaxAspdForPVP
+	// 由于扩展了 max_aspd_for_pvp 选项, 在开启了 PVP 之后
+	// 需要重算一下地图上所有玩家的攻速, 以便最新的攻速限制可以生效 [Sola丶小克]
+	if (sd) status_calc_pc(sd, SCO_NONE);
+#endif // Pandas_BattleConfig_MaxAspdForPVP
+
 	return 0;
 }
 
@@ -4623,6 +4630,12 @@ static int map_mapflag_pvp_stop_sub(struct block_list *bl, va_list ap)
 		delete_timer(sd->pvp_timer, pc_calc_pvprank_timer);
 		sd->pvp_timer = INVALID_TIMER;
 	}
+
+#ifdef Pandas_BattleConfig_MaxAspdForPVP
+	// 由于扩展了 max_aspd_for_pvp 选项, 在停止了 PVP 之后
+	// 需要重算一下地图上所有玩家的攻速, 以便最新的攻速限制可以生效 [Sola丶小克]
+	if (sd) status_calc_pc(sd, SCO_NONE);
+#endif // Pandas_BattleConfig_MaxAspdForPVP
 
 	return 0;
 }

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -13095,6 +13095,23 @@ short pc_maxparameter(struct map_session_data *sd, enum e_params param) {
 short pc_maxaspd(struct map_session_data *sd) {
 	nullpo_ret(sd);
 
+#ifdef Pandas_BattleConfig_MaxAspdForPVP
+	// 根据 max_aspd_for_pvp 约束玩家的最大攻速 [Sola丶小克]
+	if (map_flag_vs(sd->bl.m) && battle_config.max_aspd_for_pvp > 0) {
+		// 先根据 rAthena 默认的攻速公式, 计算出即将返回的攻速数值
+		int aspd = ((sd->class_ & JOBL_THIRD) ? battle_config.max_third_aspd : (
+			((sd->class_ & MAPID_UPPERMASK) == MAPID_KAGEROUOBORO || (sd->class_ & MAPID_UPPERMASK) == MAPID_REBELLION) ? battle_config.max_extended_aspd :
+			battle_config.max_aspd));
+
+		// 若 PVP 地图限制的攻速比原先 rAthena 计算的攻速更小 (限制更严格, 攻速更慢), 那么以最小的为准
+		// 需要注意: 这里返回的攻速值, 实际上是延迟的值 (值越大, 攻速越慢; 值越小, 攻速越快)
+		// 这也是为什么在 battle_adjust_conf 函数中, 需要对配置的攻速值进行加工的原因.
+		if (aspd < battle_config.max_aspd_for_pvp) {
+			return battle_config.max_aspd_for_pvp;
+		}
+	}
+#endif // Pandas_BattleConfig_MaxAspdForPVP
+
 	return (( sd->class_&JOBL_THIRD) ? battle_config.max_third_aspd : (
 			((sd->class_&MAPID_UPPERMASK) == MAPID_KAGEROUOBORO || (sd->class_&MAPID_UPPERMASK) == MAPID_REBELLION) ? battle_config.max_extended_aspd :
 			battle_config.max_aspd ));


### PR DESCRIPTION
// 玩家在 PVP 地图上的最大攻速限制 (全职业限制)
//
// 若玩家根据 conf/player.conf 的 max_aspd、max_third_aspd、
// max_extended_aspd 计算出来的最大攻速, 比此选项设置的值更加小,
// 则以更小的攻速限制为准.
// 
// 假设此选项设置为 191, 且 conf/player.conf 的 max_aspd 为 190 的话
// 若你的职业是个剑士, 且处于 PVP 地图, 那么你的最大攻速将是 190,
// 而不是此选项设置的 191 (因为 max_aspd 的限制 190 更小)
//
// 若一张地图同时启用了 PVP 和 GVG 的话, 则以 GVG 的攻速限制优先
// 若设置为 0 则关闭此限制, 最大值可填写 199
max_aspd_for_pvp: 0