### PR TITLE
使战斗配置选项可限制玩家在 GVG 地图上的最大攻速

### DIFF
--- a/conf/battle/pandas.conf
+++ b/conf/battle/pandas.conf
@@ -58,6 +58,8 @@ cashmount_useitem_limit: 64
 
 // 玩家在 PVP 地图上的最大攻速限制 (全职业限制)
 //
+// 提示: 这里的 GVG 地图是指拥有 MF_PVP 标记的地图.
+//
 // 若玩家根据 conf/player.conf 的 max_aspd、max_third_aspd、
 // max_extended_aspd 计算出来的最大攻速, 比此选项设置的值更加小,
 // 则以更小的攻速限制为准.
@@ -69,5 +71,24 @@ cashmount_useitem_limit: 64
 // 若一张地图同时启用了 PVP 和 GVG 的话, 则以 GVG 的攻速限制优先
 // 若设置为 0 则关闭此限制, 最大值可填写 199
 max_aspd_for_pvp: 0
+
+// 玩家在 GVG 地图上的最大攻速限制 (全职业限制)
+// 
+// 提示: 这里的 GVG 地图是指拥有 MF_GVG/MF_GVG_TE 标记的地图.
+// 
+// 公会城堡地图在开启 GVG 之前, 是没有 MF_GVG/MF_GVG_TE 地图标记的,
+// 因此在没有开启 GVG 的时候跑去公会城堡地图, 不会受此处限制.
+//
+// 若玩家根据 conf/player.conf 的 max_aspd、max_third_aspd、
+// max_extended_aspd 计算出来的最大攻速, 比此选项设置的值更加小,
+// 则以更小的攻速限制为准.
+// 
+// 假设此选项设置为 191, 且 conf/player.conf 的 max_aspd 为 190 的话
+// 若你的职业是个剑士, 且处于 GVG 地图, 那么你的最大攻速将是 190,
+// 而不是此选项设置的 191 (因为 max_aspd 的限制 190 更小)
+//
+// 若一张地图同时启用了 PVP 和 GVG 的话, 则以 GVG 的攻速限制优先
+// 若设置为 0 则关闭此限制, 最大值可填写 199
+max_aspd_for_gvg: 0
 
 // PYHELP - BATTLECONFIG - INSERT POINT - <Section 4>

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -181,6 +181,10 @@
 	// 是否启用 max_aspd_for_pvp 配置选项及其功能 [Sola丶小克]
 	// 此选项用于限制玩家在 PVP 地图上的最大攻击速度 (以 MF_PVP 地图标记为准)
 	#define Pandas_BattleConfig_MaxAspdForPVP
+
+	// 是否启用 max_aspd_for_gvg 配置选项及其功能 [Sola丶小克]
+	// 此选项用于限制玩家在 GVG 地图上的最大攻击速度 (以 MF_GVG/MF_GVG_TE 地图标记为准)
+	#define Pandas_BattleConfig_MaxAspdForGVG
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 1>
 #endif // Pandas_BattleConfigure
 
@@ -205,6 +209,10 @@
 	// 提示: 根据目前的 struct item 和 struct s_storage 的体积情况,
 	// 应该可支持将 MAX_INVENTORY 调整到 800 左右, 但设置越大对性能影响会越大
 	#define Pandas_FuncExtend_Increase_Inventory
+
+	// 调整 atcommand.cpp 中 atcommand_reload 配置重载指令的逻辑 [Sola丶小克]
+	// 我们希望在执行某些 reload 指令 (@reloadbattleconf) 时能重新计算全服玩家的属性和能力值
+	#define Pandas_FuncLogic_ATCOMMAND_RELOAD
 #endif // Pandas_FuncIncrease
 
 // ============================================================================

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -3910,6 +3910,25 @@ ACMD_FUNC(partyrecall)
 /*==========================================
  *
  *------------------------------------------*/
+#ifdef Pandas_FuncLogic_ATCOMMAND_RELOAD
+//************************************
+// Method:      atcommand_recalc_all
+// Description: 重新计算全服玩家的能力值属性 (用于 @reload 系列指令后的全服玩家能力值刷新使用)
+// Returns:     void
+// Author:      Sola丶小克(CairoLee)  2020/02/28 12:08
+//************************************
+static void atcommand_recalc_all() {
+	struct s_mapiterator* iter;
+	struct map_session_data* sd;
+
+	iter = mapit_geteachpc();
+	for (sd = (struct map_session_data*)mapit_first(iter); mapit_exists(iter); sd = (struct map_session_data*)mapit_next(iter)) {
+		status_calc_pc(sd, SCO_FORCE);
+	}
+	mapit_free(iter);
+}
+#endif // Pandas_FuncLogic_ATCOMMAND_RELOAD
+
 void atcommand_doload();
 ACMD_FUNC(reload) {
 	nullpo_retr(-1, sd);
@@ -3998,6 +4017,12 @@ ACMD_FUNC(reload) {
 		{	// Exp or Drop rates changed.
 			mob_reload(); //Needed as well so rate changes take effect.
 		}
+
+#ifdef Pandas_FuncLogic_ATCOMMAND_RELOAD
+		// 当执行完成 @reloadbattleconf 之后, 重新计算全服玩家的能力值属性
+		atcommand_recalc_all();
+#endif // Pandas_FuncLogic_ATCOMMAND_RELOAD
+
 		clif_displaymessage(fd, msg_txt(sd,255)); // Battle configuration has been reloaded.
 	} else if (strstr(command, "statusdb") || strncmp(message, "statusdb", 3) == 0) {
 		status_readdb();

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8688,6 +8688,9 @@ static const struct _battle_data {
 #ifdef Pandas_BattleConfig_MaxAspdForPVP
 	{ "max_aspd_for_pvp",                   &battle_config.max_aspd_for_pvp,                0,      0,      199,            },
 #endif // Pandas_BattleConfig_MaxAspdForPVP
+#ifdef Pandas_BattleConfig_MaxAspdForGVG
+	{ "max_aspd_for_gvg",                   &battle_config.max_aspd_for_gvg,                0,      0,      199,            },
+#endif // Pandas_BattleConfig_MaxAspdForGVG
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 3>
 #include "../custom/battle_config_init.inc"
 };
@@ -8771,10 +8774,27 @@ void battle_adjust_conf()
 
 #ifdef Pandas_BattleConfig_MaxAspdForPVP
 	// 根据 max_aspd_for_pvp 约束玩家的最大攻速 [Sola丶小克]
-	// 这里对配置的 ASPD 数值 (例如: 193, 197) 转换成程序判断用的攻速数值
+	// 这里对配置的 ASPD 数值 (例如: 193, 197) 转换成程序判断用的攻击间隔时间
+	// 
+	// 攻击间隔 = 2000 - 攻速的 Aspd 数值 * 10
+	// 攻击间隔 = 2000 - 193 * 10
+	// 攻击间隔 = 2000 - 1930
+	// 攻击间隔 = 70 毫秒
 	if (battle_config.max_aspd_for_pvp > 0)
 		battle_config.max_aspd_for_pvp = 2000 - battle_config.max_aspd_for_pvp * 10;
 #endif // Pandas_BattleConfig_MaxAspdForPVP
+
+#ifdef Pandas_BattleConfig_MaxAspdForGVG
+	// 根据 max_aspd_for_gvg 约束玩家的最大攻速 [Sola丶小克]
+	// 这里对配置的 ASPD 数值 (例如: 193, 197) 转换成程序判断用的攻击间隔时间
+	// 
+	// 攻击间隔 = 2000 - 攻速的 Aspd 数值 * 10
+	// 攻击间隔 = 2000 - 193 * 10
+	// 攻击间隔 = 2000 - 1930
+	// 攻击间隔 = 70 毫秒
+	if (battle_config.max_aspd_for_gvg > 0)
+		battle_config.max_aspd_for_gvg = 2000 - battle_config.max_aspd_for_gvg * 10;
+#endif // Pandas_BattleConfig_MaxAspdForGVG
 
 	if (battle_config.max_def > 100 && !battle_config.weapon_defense_type) // added by [Skotlex]
 		battle_config.max_def = 100;

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -684,8 +684,11 @@ struct Battle_Config
 	int cashmount_useitem_limit; // 乘坐“商城坐骑”时禁止使用特定类型的物品 [Sola丶小克]
 #endif // Pandas_BattleConfig_CashMounting_UseitemLimit
 #ifdef Pandas_BattleConfig_MaxAspdForPVP
-	int max_aspd_for_pvp; // 限制玩家在 PVP 时的最大攻速 [Sola丶小克]
+	int max_aspd_for_pvp; // 限制玩家在 PVP 地图上的最大攻速 [Sola丶小克]
 #endif // Pandas_BattleConfig_MaxAspdForPVP
+#ifdef Pandas_BattleConfig_MaxAspdForGVG
+	int max_aspd_for_gvg; // 限制玩家在 GVG 地图上的最大攻速 [Sola丶小克]
+#endif // Pandas_BattleConfig_MaxAspdForGVG
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 2>
 
 #include "../custom/battle_config_struct.inc"

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -13095,6 +13095,22 @@ short pc_maxparameter(struct map_session_data *sd, enum e_params param) {
 short pc_maxaspd(struct map_session_data *sd) {
 	nullpo_ret(sd);
 
+#ifdef Pandas_BattleConfig_MaxAspdForGVG
+	// 根据 max_aspd_for_gvg 约束玩家的最大攻速 [Sola丶小克]
+	if (map_flag_gvg(sd->bl.m) && battle_config.max_aspd_for_gvg > 0) {
+		// 先根据 rAthena 默认的攻速公式, 计算出即将返回的攻速数值
+		int aspd = ((sd->class_ & JOBL_THIRD) ? battle_config.max_third_aspd : (
+			((sd->class_ & MAPID_UPPERMASK) == MAPID_KAGEROUOBORO || (sd->class_ & MAPID_UPPERMASK) == MAPID_REBELLION) ? battle_config.max_extended_aspd :
+			battle_config.max_aspd));
+
+		// 若 PVP 地图限制的攻速比原先 rAthena 计算的攻速更小 (限制更严格, 攻速更慢), 那么以最小的为准
+		// 需要注意: 这里返回的攻速值, 实际上是攻击间隔延迟的毫秒数 (值越大, 攻速越慢; 值越小, 攻速越快)
+		if (aspd < battle_config.max_aspd_for_gvg) {
+			return battle_config.max_aspd_for_gvg;
+		}
+	}
+#endif // Pandas_BattleConfig_MaxAspdForGVG
+
 #ifdef Pandas_BattleConfig_MaxAspdForPVP
 	// 根据 max_aspd_for_pvp 约束玩家的最大攻速 [Sola丶小克]
 	if (map_flag_vs(sd->bl.m) && battle_config.max_aspd_for_pvp > 0) {
@@ -13104,8 +13120,7 @@ short pc_maxaspd(struct map_session_data *sd) {
 			battle_config.max_aspd));
 
 		// 若 PVP 地图限制的攻速比原先 rAthena 计算的攻速更小 (限制更严格, 攻速更慢), 那么以最小的为准
-		// 需要注意: 这里返回的攻速值, 实际上是延迟的值 (值越大, 攻速越慢; 值越小, 攻速越快)
-		// 这也是为什么在 battle_adjust_conf 函数中, 需要对配置的攻速值进行加工的原因.
+		// 需要注意: 这里返回的攻速值, 实际上是攻击间隔延迟的毫秒数 (值越大, 攻速越慢; 值越小, 攻速越快)
 		if (aspd < battle_config.max_aspd_for_pvp) {
 			return battle_config.max_aspd_for_pvp;
 		}


### PR DESCRIPTION
// 玩家在 GVG 地图上的最大攻速限制 (全职业限制)
// 
// 提示: 这里的 GVG 地图是指拥有 MF_GVG/MF_GVG_TE 标记的地图.
// 
// 公会城堡地图在开启 GVG 之前, 是没有 MF_GVG/MF_GVG_TE 地图标记的,
// 因此在没有开启 GVG 的时候跑去公会城堡地图, 不会受此处限制.
//
// 若玩家根据 conf/player.conf 的 max_aspd、max_third_aspd、
// max_extended_aspd 计算出来的最大攻速, 比此选项设置的值更加小,
// 则以更小的攻速限制为准.
// 
// 假设此选项设置为 191, 且 conf/player.conf 的 max_aspd 为 190 的话
// 若你的职业是个剑士, 且处于 GVG 地图, 那么你的最大攻速将是 190,
// 而不是此选项设置的 191 (因为 max_aspd 的限制 190 更小)
//
// 若一张地图同时启用了 PVP 和 GVG 的话, 则以 GVG 的攻速限制优先
// 若设置为 0 则关闭此限制, 最大值可填写 199
max_aspd_for_gvg: 0