### PR TITLE
修正无效的技能编号可能导致潜在的地图服务器崩溃

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -5959,6 +5959,14 @@ ACMD_FUNC(useskill)
 		return -1;
 	}
 
+	if (!skill_id) {
+		clif_displaymessage(fd, msg_txt(sd, 198)); // This skill number doesn't exist.
+		return -1;
+	}
+
+	if (!skill_lv)
+		skill_lv = 1;
+
 	if(!strcmp(atcmd_player_name,"self"))
 		pl_sd = sd; //quick keyword
 	else if ( (pl_sd = map_nick2sd(atcmd_player_name,true)) == NULL ){

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1558,6 +1558,9 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 	int inf = skill_get_inf(skill_id);
 	std::shared_ptr<s_skill_db> skill = skill_db.find(skill_id);
 
+	if (!skill)
+		return 0;
+
 	// temp: used to signal combo-skills right now.
 	if (sc && sc->data[SC_COMBO] &&
 		skill_is_combo(skill_id) &&
@@ -2034,6 +2037,9 @@ int unit_skilluse_pos2( struct block_list *src, short skill_x, short skill_y, ui
 
 	if (sc && !sc->count)
 		sc = NULL;
+
+	if (!skill_db.find(skill_id))
+		return 0;
 
 	if( sd ) {
 		if( skill_isNotOk(skill_id, sd) || !skill_check_condition_castbegin(sd, skill_id, skill_lv) )


### PR DESCRIPTION
主要解决使用 `@useskill 0 10 self` 会导致地图服务器崩溃的问题