### PR TITLE
[擴充] announce 使用bc_name，雙擊公告可將發話者ID添加至密語欄

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -6779,7 +6779,15 @@ void clif_broadcast(struct block_list* bl, const char* mes, int len, int type, e
 	p->packetType = HEADER_ZC_BROADCAST;
 	p->PacketLength = (int16)( sizeof( struct PACKET_ZC_BROADCAST ) + len );
 
-	if( ( type&BC_BLUE ) != 0 ){
+	if ((type & BC_NAME)) {
+		int16 length = (int16)(NAME_LENGTH + 4);
+
+		sprintf(p->message, "micc%s", ((TBL_PC*)bl)->status.name);
+		strncpy(&p->message[length], mes, len);
+
+		p->PacketLength += length;
+	}
+	else if( ( type&BC_BLUE ) != 0 ){
 		const char* color = "blue";
 		int16 length = (int16)strlen( color );
 

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -250,7 +250,7 @@ enum broadcast_flags : uint8_t {
 	BC_BLUE			= 0x10,
 	BC_WOE			= 0x20,
 	BC_COLOR_MASK	= 0x30, // BC_YELLOW|BC_BLUE|BC_WOE
-
+	BC_NAME			= 0x40,
 	BC_DEFAULT		= BC_ALL|BC_PC|BC_YELLOW
 };
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11851,7 +11851,7 @@ BUILDIN_FUNC(announce)
 	int         fontAlign = script_hasdata(st,7) ? script_getnum(st,7) : 0;     // default fontAlign
 	int         fontY     = script_hasdata(st,8) ? script_getnum(st,8) : 0;     // default fontY
 
-	if (flag&(BC_TARGET_MASK|BC_SOURCE_MASK)) // Broadcast source or broadcast region defined
+	if (flag&(BC_TARGET_MASK|BC_SOURCE_MASK|BC_NAME)) // Broadcast source or broadcast region defined
 	{
 		send_target target;
 		struct block_list *bl;
@@ -11878,10 +11878,23 @@ BUILDIN_FUNC(announce)
 			default:		target = ALL_CLIENT;	break; // BC_ALL
 		}
 
-		if (fontColor)
-			clif_broadcast2(bl, mes, (int)strlen(mes)+1, strtol(fontColor, (char **)NULL, 0), fontType, fontSize, fontAlign, fontY, target);
-		else
-			clif_broadcast(bl, mes, (int)strlen(mes)+1, flag&BC_COLOR_MASK, target);
+		if (flag&BC_NAME)
+		{
+			char output[CHAT_SIZE_MAX];
+
+			if (!fontColor)
+				fontColor = "0xFFFF00";
+
+			sprintf(output, "%06x%s", strtol(fontColor, (char**)NULL, 0), mes);
+			clif_broadcast(bl, output, (int)strlen(output) + 1, flag, target);
+		}
+		else {
+
+			if (fontColor)
+				clif_broadcast2(bl, mes, (int)strlen(mes) + 1, strtol(fontColor, (char**)NULL, 0), fontType, fontSize, fontAlign, fontY, target);
+			else
+				clif_broadcast(bl, mes, (int)strlen(mes) + 1, flag & BC_COLOR_MASK, target);
+		}
 	}
 	else
 	{

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -555,6 +555,7 @@
 	export_constant(BC_YELLOW);
 	export_constant(BC_BLUE);
 	export_constant(BC_WOE);
+	export_constant(BC_NAME);
 
 	/* mapflags */
 	export_constant(MF_NOMEMO);


### PR DESCRIPTION
使用方法

```
prontera,155,155,4	script	Announce	48,{

	input .@message$;
	.@message$ = sprintf("[%s]: %s", strcharinfo(0), .@message$);
	announce .@message$, bc_name, 0xff0000;
	end;
}
```