### PR TITLE
调整缓存的过期策略, 改变结构体大小将强制缓存过期

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -143,26 +143,22 @@ bool YamlDatabase::verifyCompatibility( const YAML::Node& rootNode ){
 //************************************ 
 bool YamlDatabase::isCacheEffective() {
 	IniParser rocketConfig("db/cache/rocket.ini");
-	std::string blashPath = this->getBlastCachePath();
-	std::string blashHash = this->getBlashCacheHash(blashPath);
-	uint32 count = rocketConfig.Get<uint32>(this->type + ".COUNT", 0);
+	std::string blashCachePath = this->getBlastCachePath();
+	std::string blashCacheHash = this->getBlashCacheHash(blashCachePath);
+	uint32 count = rocketConfig.Get<uint32>(this->type + ".RelatedFileCount", 0);
 
-	if (rocketConfig.Get<std::string>(this->type + ".CACHE", "") != blashPath) {
+	if (rocketConfig.Get<std::string>(this->type + ".BlastCachePath", "") != blashCachePath) {
 		return false;
 	}
 
-	if (blashHash.length() == 0 ||
-		rocketConfig.Get<std::string>(this->type + ".BLAST", "") != blashHash) {
-		return false;
-	}
-
-	if (rocketConfig.Get<uint8>(this->type + ".VERSION", 0) != this->serializeVersion) {
+	if (blashCacheHash.length() == 0 ||
+		rocketConfig.Get<std::string>(this->type + ".BlastCacheHash", "") != blashCacheHash) {
 		return false;
 	}
 
 	for (uint32 cur = 0; cur < count; cur++) {
-		std::string cfg_path = rocketConfig.Get<std::string>(this->type + ".FILE_" + std::to_string(cur), "");
-		std::string cfg_hash = rocketConfig.Get<std::string>(this->type + ".HASH_" + std::to_string(cur), "");
+		std::string cfg_path = rocketConfig.Get<std::string>(this->type + ".RelatedFile" + std::to_string(cur) + "_Path", "");
+		std::string cfg_hash = rocketConfig.Get<std::string>(this->type + ".RelatedFile" + std::to_string(cur) + "_Hash", "");
 
 		if (!isFileExists(cfg_path) || cfg_hash.length() == 0) {
 			return false;
@@ -214,11 +210,12 @@ std::string YamlDatabase::getBlashCacheHash(const std::string& path) {
 		return "";
 
 	std::string content = boost::str(
-		boost::format("%1%|%2%|%3%|%4%|%5%") %
+		boost::format("%1%|%2%|%3%|%4%|%5%|%6%") %
 		BLASTCACHE_VERSION %
 		typeid(SERIALIZE_LOAD_ARCHIVE).name() %
 		typeid(SERIALIZE_SAVE_ARCHIVE).name() %
 		this->version %
+		this->datatypeSize %
 		filehash
 	);
 
@@ -241,21 +238,21 @@ bool YamlDatabase::loadFromSerialize() {
 	{
 		std::string blashPath = this->getBlastCachePath();
 		if (this->isCacheEffective() && isFileExists(blashPath)) {
-			performance_create_and_start("yaml_blastcache");
+			performance_create_and_start("blastcache");
 			ShowStatus("Loading " CL_WHITE "%s" CL_RESET " from blast cache..." CL_CLL "\r", this->type.c_str());
 
 			std::ifstream file(blashPath, SERIALIZE_LOAD_STREAM_FLAG);
 			SERIALIZE_LOAD_ARCHIVE loadArchive(file);
 			if (this->fireSerialize<SERIALIZE_LOAD_ARCHIVE>(loadArchive)) {
-				performance_stop("yaml_blastcache");
-				ShowStatus("Done reading " CL_WHITE "%s" CL_RESET " from blast cache, took %" PRIu64 " milliseconds...\n", this->type.c_str(), performance_get_milliseconds("yaml_blastcache"));
-				performance_destory("yaml_blastcache");
+				performance_stop("blastcache");
+				ShowStatus("Done reading " CL_WHITE "%s" CL_RESET " from blast cache, took %" PRIu64 " milliseconds...\n", this->type.c_str(), performance_get_milliseconds("blastcache"));
+				performance_destory("blastcache");
 
 				this->afterSerialize();
 				return true;
 			}
 			else {
-				performance_destory("yaml_blastcache");
+				performance_destory("blastcache");
 			}
 		}
 		return false;
@@ -283,17 +280,23 @@ bool YamlDatabase::saveToSerialize() {
 	{
 		uint32 i = 0;
 		IniParser rocketConfig("db/cache/rocket.ini");
+
+		// 遍历所有关联的文件, 写入他们的路径和 Hash
 		for (auto f : this->includeFiles) {
 			std::string hash = crypto_GetFileMD5(f);
-			rocketConfig.Set(this->type + ".FILE_" + std::to_string(i), f.c_str());
-			rocketConfig.Set(this->type + ".HASH_" + std::to_string(i), hash.c_str());
+			rocketConfig.Set(this->type + ".RelatedFile" + std::to_string(i) + "_Path", f.c_str());
+			rocketConfig.Set(this->type + ".RelatedFile" + std::to_string(i) + "_Hash", hash.c_str());
 			i++;
 		}
-		rocketConfig.Set(this->type + ".COUNT", std::to_string(i));
 
+		// 记录关联文件的总数
+		rocketConfig.Set(this->type + ".RelatedFileCount", std::to_string(i));
+
+		// 记录序列化缓存文件的所在路径
 		std::string blashPath = this->getBlastCachePath();
-		rocketConfig.Set(this->type + ".CACHE", blashPath);
+		rocketConfig.Set(this->type + ".BlastCachePath", blashPath);
 
+		// 执行序列化 (保存缓存数据)
 		bool fireResult = false;
 		{
 			std::ofstream file(blashPath, SERIALIZE_SAVE_STREAM_FLAG);
@@ -301,10 +304,10 @@ bool YamlDatabase::saveToSerialize() {
 			fireResult = this->fireSerialize<SERIALIZE_SAVE_ARCHIVE>(saveArchive);
 		}
 
+		// 如果缓存成功, 那么记录缓存的 Hash 和版本号
 		if (fireResult) {
 			std::string blashHash = this->getBlashCacheHash(blashPath);
-			rocketConfig.Set(this->type + ".BLAST", blashHash);
-			rocketConfig.Set(this->type + ".VERSION", this->serializeVersion);
+			rocketConfig.Set(this->type + ".BlastCacheHash", blashHash);
 		}
 
 		return fireResult;
@@ -323,17 +326,24 @@ bool YamlDatabase::load(){
 
 	this->loadingFinished();
 #else
+	// 清空关联文件记录
 	this->includeFiles.clear();
 
+	// 如果已经从缓存加载, 那么执行 loadingFinished 后直接返回
 	if (this->loadFromSerialize()) {
 		this->loadingFinished();
 		return true;
 	}
 
+	// 如果缓存失效, 那么下面执行全新加载
 	bool ret = this->load( this->getDefaultLocation() );
+
+	// 如果加载成功, 那么将加载成功后的数据进行缓存
 	if (ret) {
 		this->saveToSerialize();
 	}
+
+	// 并执行 loadingFinished 进行一些数据初始化工作
 	this->loadingFinished();
 #endif // Pandas_YamlBlastCache_Serialize
 
@@ -358,6 +368,7 @@ bool YamlDatabase::load(const std::string& path) {
 #endif // Pandas_Console_Translate
 
 #ifdef Pandas_YamlBlastCache_Serialize
+	// 这个文件与当前数据库相关, 插入到关联文件记录中
 	this->includeFiles.insert(path);
 #endif // Pandas_YamlBlastCache_Serialize
 

--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -94,8 +94,14 @@ protected:
 	virtual void loadingFinished();
 
 #ifdef Pandas_YamlBlastCache_Serialize
+	// 用于设置此类的实例是否支持疾风缓存
+	// 如若设为 true 则将尝试对数据进行缓存读写操作,
+	// 想要为 YamlDatabase 的子类开启缓存功能之前, 必须先定义需要对哪些结构体进行序列化
 	bool supportSerialize = false;
-	uint8 serializeVersion = 0;
+
+	// 用于记录被缓存的数据类型的大小
+	// 以便在通过宏定义修改数据体积后能够在 struct 长度变更时让缓存过期
+	uint32 datatypeSize = 0;
 #endif // Pandas_YamlBlastCache_Serialize
 
 public:
@@ -171,9 +177,15 @@ protected:
 
 public:
 	TypesafeYamlDatabase( const std::string type_, uint16 version_, uint16 minimumVersion_ ) : YamlDatabase( type_, version_, minimumVersion_ ){
+#ifdef Pandas_YamlBlastCache_Serialize
+		this->datatypeSize = sizeof(datatype);
+#endif // Pandas_YamlBlastCache_Serialize
 	}
 
 	TypesafeYamlDatabase( const std::string& type_, uint16 version_ ) : YamlDatabase( type_, version_, version_ ){
+#ifdef Pandas_YamlBlastCache_Serialize
+		this->datatypeSize = sizeof(datatype);
+#endif // Pandas_YamlBlastCache_Serialize
 	}
 
 	void clear(){
@@ -253,11 +265,15 @@ private:
 
 public:
 	TypesafeCachedYamlDatabase( const std::string type_, uint16 version_, uint16 minimumVersion_ ) : TypesafeYamlDatabase<keytype, datatype>( type_, version_, minimumVersion_ ){
-
+#ifdef Pandas_YamlBlastCache_Serialize
+		this->datatypeSize = sizeof(datatype);
+#endif // Pandas_YamlBlastCache_Serialize
 	}
 
 	TypesafeCachedYamlDatabase( const std::string& type_, uint16 version_ ) : TypesafeYamlDatabase<keytype, datatype>( type_, version_, version_ ){
-
+#ifdef Pandas_YamlBlastCache_Serialize
+		this->datatypeSize = sizeof(datatype);
+#endif // Pandas_YamlBlastCache_Serialize
 	}
 
 	void clear() override{

--- a/src/common/serialize.hpp
+++ b/src/common/serialize.hpp
@@ -26,13 +26,13 @@
 
 //************************************
 // 此处的疾风缓存版本会被纳入缓存散列的计算过程中
-// 变缓存版本会导致所有缓存过期
+// 注意: 变缓存版本会导致所有缓存过期
 //************************************
-#define BLASTCACHE_VERSION 20210124
+#define BLASTCACHE_VERSION 20210727
 
 //************************************
 // 若想启用二进制格式的缓存, 则启用此段代码(并禁用其他)
-// 变更缓存格式会导致所有缓存过期
+// 注意: 变更缓存格式会导致所有缓存过期
 //************************************
 #define SERIALIZE_SAVE_ARCHIVE boost::archive::binary_oarchive
 #define SERIALIZE_SAVE_STREAM_FLAG std::ofstream::binary | std::ofstream::out
@@ -41,7 +41,7 @@
 
 //************************************
 // 若想启用文本格式的缓存, 则启用此段代码(并禁用其他)
-// 变更缓存格式会导致所有缓存过期
+// 注意: 变更缓存格式会导致所有缓存过期
 //************************************
 // #define SERIALIZE_SAVE_ARCHIVE boost::archive::text_oarchive
 // #define SERIALIZE_SAVE_STREAM_FLAG std::ofstream::out

--- a/src/map/itemdb.hpp
+++ b/src/map/itemdb.hpp
@@ -1091,7 +1091,6 @@ public:
 	ItemDatabase() : TypesafeCachedYamlDatabase("ITEM_DB", 1) {
 #ifdef Pandas_YamlBlastCache_ItemDatabase
 		this->supportSerialize = true;
-		this->serializeVersion = 2;
 #endif // Pandas_YamlBlastCache_ItemDatabase
 	}
 

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -265,7 +265,6 @@ public:
 	MobDatabase() : TypesafeCachedYamlDatabase("MOB_DB", 2, 1) {
 #ifdef Pandas_YamlBlastCache_MobDatabase
 		this->supportSerialize = true;
-		this->serializeVersion = 1;
 #endif // Pandas_YamlBlastCache_MobDatabase
 	}
 

--- a/src/map/quest.hpp
+++ b/src/map/quest.hpp
@@ -71,7 +71,6 @@ public:
 	QuestDatabase() : TypesafeYamlDatabase("QUEST_DB", 2, 1) {
 #ifdef Pandas_YamlBlastCache_QuestDatabase
 		this->supportSerialize = true;
-		this->serializeVersion = 1;
 #endif // Pandas_YamlBlastCache_QuestDatabase
 	}
 

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -317,7 +317,6 @@ public:
 	SkillDatabase() : TypesafeCachedYamlDatabase("SKILL_DB", 1) {
 #ifdef Pandas_YamlBlastCache_SkillDatabase
 		this->supportSerialize = true;
-		this->serializeVersion = 1;
 #endif // Pandas_YamlBlastCache_SkillDatabase
 	}
 


### PR DESCRIPTION
此提交将解决 #383 中出现的情况，
此后，改变与结构体长度相关的宏定义将无需手动删除缓存