### PR TITLE
修正 `@item` 等指令只能使用 AegisName 来创造道具的问题

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -743,6 +743,11 @@
 // ============================================================================
 
 #ifdef Pandas_Bugfix
+	// 修正 @item 等指令只能使用 AegisName 来创造道具的问题 [Sola丶小克]
+	// 此问题由 rAthena 的 6b84115 号提交引入, 相关链接如下:
+	// https://github.com/rathena/rathena/commit/6b841157909ac17c0b82b917763976f43be2f89f
+	#define Pandas_Fix_Itemdb_Searchname_Logic
+
 	// 修正 mail_attachment_weight 选项在特定操作顺序下无效的问题 [Sola丶小克]
 	// 若一次性放入超过 mail_attachment_weight 负重限制的道具到邮件中时, 程序可以正常的判断出超重
 	// 但是若分多次, 放入相同一件物品到邮件附件中, 那么 mail_attachment_weight 的负重限制将会失去作用

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -1300,7 +1300,17 @@ std::shared_ptr<item_data> ItemDatabase::searchname( const char* name ){
 	// Convert it to lower
 	util::tolower( lowername );
 
+#ifndef Pandas_Fix_Itemdb_Searchname_Logic
 	return util::umap_find( this->aegisNameToItemDataMap, lowername );
+#else
+	std::shared_ptr<item_data> result = util::umap_find(this->nameToItemDataMap, lowername);
+
+	if (result != nullptr) {
+		return result;
+	}
+
+	return util::umap_find(this->aegisNameToItemDataMap, lowername);
+#endif // Pandas_Fix_Itemdb_Searchname_Logic
 }
 
 std::shared_ptr<item_data> ItemDatabase::search_aegisname( const char *name ){


### PR DESCRIPTION
该提交应该解决了 #404 提到的情况

### 以前
**itemdb_searchname**：先搜索 aegisname，再搜索 ename
**itemdb_search_aegisname**：只搜索 aegisname

### 现在
**ItemDatabase::searchname**：只搜索 aegisname
**ItemDatabase::search_aegisname**：先搜索 aegisname，再搜索 ename

### 改成
**ItemDatabase::searchname**：`先搜索 ename`，再搜索 aegisname
**ItemDatabase::search_aegisname**：先搜索 aegisname，再搜索 ename
