### PR TITLE
修正角色配置接口在同账号下的不同角色信息会相互覆盖的问题

### DIFF
--- a/3rdparty/nlohmann_json/json.hpp
+++ b/3rdparty/nlohmann_json/json.hpp
@@ -26322,7 +26322,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     @since version 3.0.0
     */
-    void merge_patch(const basic_json& apply_patch, bool erase_null = true)
+    void merge_patch(const basic_json& apply_patch)
     {
         if (apply_patch.is_object())
         {
@@ -26334,18 +26334,54 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             {
                 if (it.value().is_null())
                 {
-					if (erase_null)
-						erase(it.key());
+                    erase(it.key());
                 }
                 else
                 {
-                    operator[](it.key()).merge_patch(it.value(), erase_null);
+                    operator[](it.key()).merge_patch(it.value());
                 }
             }
         }
         else
         {
             *this = apply_patch;
+        }
+    }
+
+	//************************************
+	// Method:      merge_patch_v2
+	// Description: 能够允许不合入 patch 中值为 null 的字段
+	// Access:      public 
+	// Parameter:   const basic_json & apply_patch
+	// Parameter:   bool merge_null
+	// Returns:     void
+	// Author:      Sola丶小克(CairoLee)  2021/10/03 23:55
+	//************************************ 
+	void merge_patch_v2(const basic_json& apply_patch, bool merge_null = true)
+    {
+        if (apply_patch.is_object())
+        {
+            if (!is_object())
+            {
+                *this = object();
+            }
+            for (auto it = apply_patch.begin(); it != apply_patch.end(); ++it)
+            {
+                if (it.value().is_null())
+                {
+					if (merge_null)
+						erase(it.key());
+                }
+                else
+                {
+                    operator[](it.key()).merge_patch_v2(it.value(), merge_null);
+                }
+            }
+        }
+        else
+        {
+			if ((apply_patch.is_null() && merge_null) || (!apply_patch.is_null()))
+				*this = apply_patch;
         }
     }
 

--- a/3rdparty/nlohmann_json/json.hpp
+++ b/3rdparty/nlohmann_json/json.hpp
@@ -26357,7 +26357,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 	// Returns:     void
 	// Author:      Sola丶小克(CairoLee)  2021/10/03 23:55
 	//************************************ 
-	void merge_patch_v2(const basic_json& apply_patch, bool merge_null = true)
+    void merge_patch_v2(const basic_json& apply_patch, bool merge_null = true)
     {
         if (apply_patch.is_object())
         {
@@ -26369,8 +26369,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             {
                 if (it.value().is_null())
                 {
-					if (merge_null)
-						erase(it.key());
+                    if (merge_null)
+                        erase(it.key());
                 }
                 else
                 {
@@ -26380,8 +26380,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         }
         else
         {
-			if ((apply_patch.is_null() && merge_null) || (!apply_patch.is_null()))
-				*this = apply_patch;
+            if ((apply_patch.is_null() && merge_null) || (!apply_patch.is_null()))
+                *this = apply_patch;
         }
     }
 

--- a/3rdparty/nlohmann_json/nlohmann_json.natvis
+++ b/3rdparty/nlohmann_json/nlohmann_json.natvis
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="nlohmann::basic_json&lt;*&gt;">
+        <DisplayString Condition="m_type == nlohmann::detail::value_t::null">null</DisplayString>
+        <DisplayString Condition="m_type == nlohmann::detail::value_t::object">{*(m_value.object)}</DisplayString>
+        <DisplayString Condition="m_type == nlohmann::detail::value_t::array">{*(m_value.array)}</DisplayString>
+        <DisplayString Condition="m_type == nlohmann::detail::value_t::string">{*(m_value.string)}</DisplayString>
+        <DisplayString Condition="m_type == nlohmann::detail::value_t::boolean">{m_value.boolean}</DisplayString>
+        <DisplayString Condition="m_type == nlohmann::detail::value_t::number_integer">{m_value.number_integer}</DisplayString>
+        <DisplayString Condition="m_type == nlohmann::detail::value_t::number_unsigned">{m_value.number_unsigned}</DisplayString>
+        <DisplayString Condition="m_type == nlohmann::detail::value_t::number_float">{m_value.number_float}</DisplayString>
+        <DisplayString Condition="m_type == nlohmann::detail::value_t::discarded">discarded</DisplayString>
+        <Expand>
+            <ExpandedItem Condition="m_type == nlohmann::detail::value_t::object">
+                *(m_value.object),view(simple)
+            </ExpandedItem>
+            <ExpandedItem Condition="m_type == nlohmann::detail::value_t::array">
+                *(m_value.array),view(simple)
+            </ExpandedItem>
+        </Expand>
+    </Type>
+
+    <!--    skip the pair first/second members in the treeview while traversing a map.
+            Only works in VS 2015 Update 2 and beyond using the new visualization -->
+    <Type Name="std::pair&lt;*, nlohmann::basic_json&lt;*&gt;&gt;" IncludeView="MapHelper">
+        <DisplayString>{second}</DisplayString>
+        <Expand>
+            <ExpandedItem>second</ExpandedItem>
+        </Expand>
+    </Type>
+
+</AutoVisualizer>

--- a/sql-files/composer/web/upgrade_to_1.1.7_web.sql
+++ b/sql-files/composer/web/upgrade_to_1.1.7_web.sql
@@ -1,0 +1,12 @@
+-- ------------------------------------------------------------------------------
+-- 此脚本用于将 Pandas 的 WEB 接口数据库升级到 1.1.7 版本
+-- 注意: 若存在更低版本且从未导入的升级脚本, 请按版本号从小到大依序导入
+-- ------------------------------------------------------------------------------
+
+ALTER TABLE `char_configs`
+	ADD COLUMN `char_id` INT(11) UNSIGNED NOT NULL AFTER `account_id`,
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`account_id`, `char_id`, `world_name`);
+
+DELETE FROM `char_configs` WHERE `char_id` = 0;
+

--- a/sql-files/web.sql
+++ b/sql-files/web.sql
@@ -30,7 +30,8 @@ CREATE TABLE IF NOT EXISTS `user_configs` (
 
 CREATE TABLE IF NOT EXISTS `char_configs` (
   `account_id` int(11) unsigned NOT NULL,
+  `char_id` INT(11) UNSIGNED NOT NULL,	-- Pandas add this field for distinguish character data
   `world_name` varchar(32) NOT NULL,
   `data` longtext NOT NULL,
-  PRIMARY KEY (`account_id`, `world_name`)
+  PRIMARY KEY (`account_id`, `char_id`, `world_name`)	-- Pandas add char_id field into primary key
 ) ENGINE=MyISAM;

--- a/src/web/charconfig_controller.cpp
+++ b/src/web/charconfig_controller.cpp
@@ -171,19 +171,52 @@ HANDLER_FUNC(charconfig_save) {
 	}
 	
 	auto account_id = std::stoi(req.get_file_value("AID").content);
+	auto char_id = std::stoi(req.get_file_value("GID").content);
 	auto world_name_str = U2AWE(req.get_file_value("WorldName").content);
 	auto world_name = world_name_str.c_str();
 	std::string data = U2AWE(req.get_file_value("data").content);
+
+	// =============== 确保 AID (账号编号) 和 GID (角色编号) 合法存在 ===============
+	SQLLock charlock(CHAR_SQL_LOCK);
+	charlock.lock();
+	auto char_handle = charlock.getHandle();
+	SqlStmt* char_stmt = SqlStmt_Malloc(char_handle);
+
+	if (SQL_SUCCESS != SqlStmt_Prepare(char_stmt,
+		"SELECT `char_id` FROM `%s` WHERE (`account_id` = ? AND `char_id` = ?) LIMIT 1",
+		char_db_table)
+		|| SQL_SUCCESS != SqlStmt_BindParam(char_stmt, 0, SQLDT_INT, &account_id, sizeof(account_id))
+		|| SQL_SUCCESS != SqlStmt_BindParam(char_stmt, 1, SQLDT_INT, &char_id, sizeof(char_id))
+		|| SQL_SUCCESS != SqlStmt_Execute(char_stmt)
+		) {
+		SqlStmt_ShowDebug(char_stmt);
+		SqlStmt_Free(char_stmt);
+		charlock.unlock();
+		response_json(res, 502, 3, "There is an exception in the database table structure.");
+		return;
+	}
+
+	if (SqlStmt_NumRows(char_stmt) <= 0) {
+		SqlStmt_Free(char_stmt);
+		charlock.unlock();
+		response_json(res, 400, 3, "The character specified by the \"GID\" does not exist in the account.");
+		return;
+	}
+
+	SqlStmt_Free(char_stmt);
+	charlock.unlock();
+	// ========================================================================
 
 	SQLLock sl(WEB_SQL_LOCK);
 	sl.lock();
 	auto handle = sl.getHandle();
 	SqlStmt * stmt = SqlStmt_Malloc(handle);
 	if (SQL_SUCCESS != SqlStmt_Prepare(stmt,
-			"SELECT `data` FROM `%s` WHERE (`account_id` = ? AND `world_name` = ?) LIMIT 1",
+			"SELECT `data` FROM `%s` WHERE (`account_id` = ? AND `char_id` = ? AND `world_name` = ?) LIMIT 1",
 			char_configs_table)
 		|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 0, SQLDT_INT, &account_id, sizeof(account_id))
-		|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 1, SQLDT_STRING, (void *)world_name, strlen(world_name))
+		|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 1, SQLDT_INT, &char_id, sizeof(char_id))
+		|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 2, SQLDT_STRING, (void *)world_name, strlen(world_name))
 		|| SQL_SUCCESS != SqlStmt_Execute(stmt)
 	) {
 		SqlStmt_ShowDebug(stmt);
@@ -217,11 +250,12 @@ HANDLER_FUNC(charconfig_save) {
 
 	if (SqlStmt_NumRows(stmt) <= 0) {
 		if (SQL_SUCCESS != SqlStmt_Prepare(stmt,
-				"INSERT INTO `%s` (`account_id`, `world_name`, `data`) VALUES (?, ?, ?)",
+				"INSERT INTO `%s` (`account_id`, `char_id`, `world_name`, `data`) VALUES (?, ?, ?, ?)",
 				char_configs_table)
 			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 0, SQLDT_INT, &account_id, sizeof(account_id))
-			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 1, SQLDT_STRING, (void *)world_name, strlen(world_name))
-			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 2, SQLDT_STRING, (void *)data.c_str(), strlen(data.c_str()))
+			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 1, SQLDT_INT, &char_id, sizeof(char_id))
+			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 2, SQLDT_STRING, (void *)world_name, strlen(world_name))
+			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 3, SQLDT_STRING, (void *)data.c_str(), strlen(data.c_str()))
 			|| SQL_SUCCESS != SqlStmt_Execute(stmt)
 		) {
 			SqlStmt_ShowDebug(stmt);
@@ -232,11 +266,12 @@ HANDLER_FUNC(charconfig_save) {
 		}
 	} else {
 		if (SQL_SUCCESS != SqlStmt_Prepare(stmt,
-				"UPDATE `%s` SET `data` = ? WHERE (`account_id` = ? AND `world_name` = ?)",
+				"UPDATE `%s` SET `data` = ? WHERE (`account_id` = ? AND `char_id` = ? AND `world_name` = ?)",
 				char_configs_table)
 			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 0, SQLDT_STRING, (void *)data.c_str(), strlen(data.c_str()))
 			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 1, SQLDT_INT, &account_id, sizeof(account_id))
-			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 2, SQLDT_STRING, (void *)world_name, strlen(world_name))
+			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 2, SQLDT_INT, &char_id, sizeof(char_id))
+			|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 3, SQLDT_STRING, (void *)world_name, strlen(world_name))
 			|| SQL_SUCCESS != SqlStmt_Execute(stmt)
 		) {
 			SqlStmt_ShowDebug(stmt);
@@ -260,18 +295,51 @@ HANDLER_FUNC(charconfig_load) {
 	}
 
 	auto account_id = std::stoi(req.get_file_value("AID").content);
+	auto char_id = std::stoi(req.get_file_value("GID").content);
 	auto world_name_str = U2AWE(req.get_file_value("WorldName").content);
 	auto world_name = world_name_str.c_str();
+
+	// =============== 确保 AID (账号编号) 和 GID (角色编号) 合法存在 ===============
+	SQLLock charlock(CHAR_SQL_LOCK);
+	charlock.lock();
+	auto char_handle = charlock.getHandle();
+	SqlStmt* char_stmt = SqlStmt_Malloc(char_handle);
+
+	if (SQL_SUCCESS != SqlStmt_Prepare(char_stmt,
+		"SELECT `char_id` FROM `%s` WHERE (`account_id` = ? AND `char_id` = ?) LIMIT 1",
+		char_db_table)
+		|| SQL_SUCCESS != SqlStmt_BindParam(char_stmt, 0, SQLDT_INT, &account_id, sizeof(account_id))
+		|| SQL_SUCCESS != SqlStmt_BindParam(char_stmt, 1, SQLDT_INT, &char_id, sizeof(char_id))
+		|| SQL_SUCCESS != SqlStmt_Execute(char_stmt)
+		) {
+		SqlStmt_ShowDebug(char_stmt);
+		SqlStmt_Free(char_stmt);
+		charlock.unlock();
+		response_json(res, 502, 3, "There is an exception in the database table structure.");
+		return;
+	}
+
+	if (SqlStmt_NumRows(char_stmt) <= 0) {
+		SqlStmt_Free(char_stmt);
+		charlock.unlock();
+		response_json(res, 400, 3, "The character specified by the \"GID\" does not exist in the account.");
+		return;
+	}
+
+	SqlStmt_Free(char_stmt);
+	charlock.unlock();
+	// ========================================================================
 
 	SQLLock sl(WEB_SQL_LOCK);
 	sl.lock();
 	auto handle = sl.getHandle();
 	SqlStmt * stmt = SqlStmt_Malloc(handle);
 	if (SQL_SUCCESS != SqlStmt_Prepare(stmt,
-			"SELECT `data` FROM `%s` WHERE (`account_id` = ? AND `world_name` = ?) LIMIT 1",
+			"SELECT `data` FROM `%s` WHERE (`account_id` = ? AND `char_id` = ? AND `world_name` = ?) LIMIT 1",
 			char_configs_table)
 		|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 0, SQLDT_INT, &account_id, sizeof(account_id))
-		|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 1, SQLDT_STRING, (void *)world_name, strlen(world_name))
+		|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 1, SQLDT_INT, &char_id, sizeof(char_id))
+		|| SQL_SUCCESS != SqlStmt_BindParam(stmt, 2, SQLDT_STRING, (void *)world_name, strlen(world_name))
 		|| SQL_SUCCESS != SqlStmt_Execute(stmt)
 	) {
 		SqlStmt_ShowDebug(stmt);

--- a/src/web/charconfig_controller.cpp
+++ b/src/web/charconfig_controller.cpp
@@ -243,7 +243,7 @@ HANDLER_FUNC(charconfig_save) {
 			json data_from_db = json::parse(A2UWE(databuf));
 			json data_from_client = json::parse(req.get_file_value("data").content);
 
-			data_from_db.merge_patch(data_from_client, false);
+			data_from_db.merge_patch_v2(data_from_client, false);
 			data = U2AWE(data_from_db.dump(3));
 		}
 	}

--- a/src/web/userconfig_controller.cpp
+++ b/src/web/userconfig_controller.cpp
@@ -210,7 +210,7 @@ HANDLER_FUNC(userconfig_save) {
 			json data_from_db = json::parse(A2UWE(databuf));
 			json data_from_client = json::parse(req.get_file_value("data").content);
 
-			data_from_db.merge_patch(data_from_client, false);
+			data_from_db.merge_patch_v2(data_from_client, false);
 			data = U2AWE(data_from_db.dump(3));
 		}
 	}

--- a/tools/python/dawn_publish.py
+++ b/tools/python/dawn_publish.py
@@ -258,6 +258,9 @@ def arrange_common(packagedir):
     os.makedirs(packagedir + 'sql-files/web/creation')
     shutil.move(packagedir + 'sql-files/web.sql', packagedir + 'sql-files/web/creation/01.web.sql')
     
+    if os.path.exists(packagedir + 'sql-files/composer/web'):
+        shutil.move(packagedir + 'sql-files/composer/web', packagedir + 'sql-files/web/upgrades')
+    
     # 清理工作
     rmdir(packagedir + 'sql-files/composer')
     rmdir(packagedir + 'sql-files/compatibility')


### PR DESCRIPTION
问题描述
------------------
原先的 web-server 并没有对角色配置接口（charconfig）进行角色的区分
因此相同账号不同角色的技能等级设置信息会被相互覆盖

此提交中我们在 `char_configs` 表中加入了 `char_id` 字段，并将相同账号下不同角色的信息区分存放。

注册表信息
------------------
每次客户端通过 /charconfig/load 拉取到技能信息后会存放在注册表：
`HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Gravity Soft\Ragnarok\ShortcutItem`

应用此提交之前
------------------
- 账号 1 建立两个角色：A、B
- 给 A 和 B 分配几个三转职业，并执行 allskill 学习所有技能
- 进入 A 角色，在 ALT+S 面板中随便找一个多等级技能，将他的等级降低一级（比如 A 是法师系，那么火箭术调整为 9 级）
- 登出 A 角色，此时 char_configs 将记录账号 1 的技能等级详情为 A 角色的配置
- 进入 B 角色，在 ALT+S 面中找一个多等级技能，将他的等级降低两级（比如 B 是牧师系，那么治愈术调整为 8 级）
- 登出 B 角色，此时 char_configs 将记录账号 1 的技能等级详情为 B 角色的配置（覆盖了 A 角色的配置）
- 关闭客户端
- 删除注册表中的客户端本地记录（参考上面 `注册表信息`）
- 重新打开客户端，进入 A 角色，打开 ALT+S 面板，会看到火箭术自定义技能级别变成了 10（预期为 9）
- 登出角色 A，进入角色 B，此时由于服务端保存的配置就是角色 B 的配置，因此角色 B 的 治愈术的自定义等级将会是 8 级

应用此提交之后
------------------
- 各角色的配置相互独立，不存在相互覆盖的问题