### PR TITLE
使疾风缓存支持新的两个数据库 (缓存后 DEBUG 模式启动速度缩减 10 秒)

### DIFF
--- a/src/common/serialize.hpp
+++ b/src/common/serialize.hpp
@@ -17,6 +17,7 @@
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 #include <boost/serialization/vector.hpp>
+#include <boost/serialization/array.hpp>
 #include <boost/serialization/string.hpp>
 #include <boost/serialization/set.hpp>
 #include <boost/serialization/bitset.hpp>
@@ -29,7 +30,7 @@
 // 此处的疾风缓存版本会被纳入缓存散列的计算过程中
 // 注意: 变缓存版本会导致所有缓存过期
 //************************************
-#define BLASTCACHE_VERSION 20210727
+#define BLASTCACHE_VERSION 20211225
 
 //************************************
 // 若想启用二进制格式的缓存, 则启用此段代码(并禁用其他)

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1186,6 +1186,9 @@
 
 		// 是否启用对 JobDatabase 的序列化支持 [Sola丶小克]
 		#define Pandas_YamlBlastCache_JobDatabase
+
+		// 是否启用对 SkillTreeDatabase 的序列化支持 [Sola丶小克]
+		#define Pandas_YamlBlastCache_SkillTreeDatabase
 	#endif // Pandas_YamlBlastCache_Serialize
 #endif // Pandas_YamlBlastCache
 

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1183,6 +1183,9 @@
 
 		// 是否启用对 RandomOptionGroupDatabase 的序列化支持 [Sola丶小克]
 		#define Pandas_YamlBlastCache_RandomOptionGroupDatabase
+
+		// 是否启用对 JobDatabase 的序列化支持 [Sola丶小克]
+		#define Pandas_YamlBlastCache_JobDatabase
 	#endif // Pandas_YamlBlastCache_Serialize
 #endif // Pandas_YamlBlastCache
 

--- a/src/map/itemdb.hpp
+++ b/src/map/itemdb.hpp
@@ -1054,15 +1054,6 @@ struct s_random_opt_group {
 };
 
 class RandomOptionDatabase : public TypesafeYamlDatabase<uint16, s_random_opt_data> {
-#ifdef Pandas_YamlBlastCache_RandomOptionDatabase
-private:
-	friend class boost::serialization::access;
-
-	template <typename Archive>
-	void serialize(Archive& ar, const unsigned int version) {
-		ar& boost::serialization::base_object<TypesafeYamlDatabase<uint16, s_random_opt_data>>(*this);
-	}
-#endif // Pandas_YamlBlastCache_RandomOptionDatabase
 public:
 	RandomOptionDatabase() : TypesafeYamlDatabase("RANDOM_OPTION_DB", 1) {
 #ifdef Pandas_YamlBlastCache_RandomOptionDatabase
@@ -1087,15 +1078,6 @@ public:
 extern RandomOptionDatabase random_option_db;
 
 class RandomOptionGroupDatabase : public TypesafeYamlDatabase<uint16, s_random_opt_group> {
-#ifdef Pandas_YamlBlastCache_RandomOptionGroupDatabase
-private:
-	friend class boost::serialization::access;
-
-	template <typename Archive>
-	void serialize(Archive& ar, const unsigned int version) {
-		ar& boost::serialization::base_object<TypesafeYamlDatabase<uint16, s_random_opt_group>>(*this);
-	}
-#endif // Pandas_YamlBlastCache_RandomOptionGroupDatabase
 public:
 	RandomOptionGroupDatabase() : TypesafeYamlDatabase("RANDOM_OPTION_GROUP", 1) {
 #ifdef Pandas_YamlBlastCache_RandomOptionGroupDatabase
@@ -1170,15 +1152,6 @@ public:
 extern ItemDatabase item_db;
 
 class ItemGroupDatabase : public TypesafeCachedYamlDatabase<uint16, s_item_group_db> {
-#ifdef Pandas_YamlBlastCache_ItemGroupDatabase
-private:
-	friend class boost::serialization::access;
-
-	template <typename Archive>
-	void serialize(Archive& ar, const unsigned int version) {
-		ar& boost::serialization::base_object<TypesafeCachedYamlDatabase<uint16, s_item_group_db>>(*this);
-	}
-#endif // Pandas_YamlBlastCache_ItemGroupDatabase
 public:
 	ItemGroupDatabase() : TypesafeCachedYamlDatabase("ITEM_GROUP_DB", 1) {
 #ifdef Pandas_YamlBlastCache_ItemGroupDatabase
@@ -1469,6 +1442,5 @@ namespace boost {
 	} // namespace serialization
 } // namespace boost
 #endif // Pandas_YamlBlastCache_RandomOptionGroupDatabase
-
 
 #endif /* ITEMDB_HPP */

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -266,14 +266,6 @@ struct s_mob_db {
 
 class MobDatabase : public TypesafeCachedYamlDatabase <uint32, s_mob_db> {
 private:
-#ifdef Pandas_YamlBlastCache_MobDatabase
-	friend class boost::serialization::access;
-
-	template <typename Archive>
-	void serialize(Archive& ar, const unsigned int version) {
-		ar& boost::serialization::base_object<TypesafeCachedYamlDatabase<uint32, s_mob_db>>(*this);
-	}
-#endif // Pandas_YamlBlastCache_MobDatabase
 
 	bool parseDropNode(std::string nodeName, YAML::Node node, uint8 max, s_mob_drop *drops);
 

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -13838,6 +13838,51 @@ void JobDatabase::loadingFinished() {
 	}
 }
 
+#ifdef Pandas_YamlBlastCache_JobDatabase
+//************************************
+// Method:      doSerialize
+// Description: 对 JobDatabase 进行序列化和反序列化操作
+// Access:      public 
+// Parameter:   const std::string & type
+// Parameter:   void * archive
+// Returns:     bool
+// Author:      Sola丶小克(CairoLee)  2021/12/25 15:06
+//************************************ 
+bool JobDatabase::doSerialize(const std::string& type, void* archive) {
+	if (type == typeid(SERIALIZE_SAVE_ARCHIVE).name()) {
+		SERIALIZE_SAVE_ARCHIVE* ar = (SERIALIZE_SAVE_ARCHIVE*)archive;
+		ARCHIVEPTR_REGISTER_TYPE(ar, JobDatabase);
+		*ar&* this;
+		return true;
+	}
+	else if (type == typeid(SERIALIZE_LOAD_ARCHIVE).name()) {
+		SERIALIZE_LOAD_ARCHIVE* ar = (SERIALIZE_LOAD_ARCHIVE*)archive;
+		ARCHIVEPTR_REGISTER_TYPE(ar, JobDatabase);
+		*ar&* this;
+		return true;
+	}
+	return false;
+}
+
+//************************************
+// Method:      afterSerialize
+// Description: 反序列化完成之后对 JobDatabase 中的对象进行加工处理
+// Access:      public 
+// Returns:     void
+// Author:      Sola丶小克(CairoLee)  2021/12/25 15:06
+//************************************ 
+void JobDatabase::afterSerialize() {
+	for (const auto& it : *this) {
+		auto job = it.second;
+
+		// ==================================================================
+		// 反序列化后将未参与序列化的字段进行初始化, 避免内存中的脏数据对工作造成错误的影响
+		// ==================================================================
+		SERIALIZE_SET_MEMORY_ZERO(job->noenter_map);
+	}
+}
+#endif // Pandas_YamlBlastCache_JobDatabase
+
 /**
  * Read job_noenter_map.txt
  **/

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -13292,6 +13292,44 @@ void SkillTreeDatabase::loadingFinished() {
 	}
 }
 
+#ifdef Pandas_YamlBlastCache_SkillTreeDatabase
+//************************************
+// Method:      SkillTreeDatabase
+// Description: 对 JobDatabase 进行序列化和反序列化操作
+// Access:      public 
+// Parameter:   const std::string & type
+// Parameter:   void * archive
+// Returns:     bool
+// Author:      Sola丶小克(CairoLee)  2021/12/25 15:55
+//************************************ 
+bool SkillTreeDatabase::doSerialize(const std::string& type, void* archive) {
+	if (type == typeid(SERIALIZE_SAVE_ARCHIVE).name()) {
+		SERIALIZE_SAVE_ARCHIVE* ar = (SERIALIZE_SAVE_ARCHIVE*)archive;
+		ARCHIVEPTR_REGISTER_TYPE(ar, SkillTreeDatabase);
+		*ar&* this;
+		return true;
+	}
+	else if (type == typeid(SERIALIZE_LOAD_ARCHIVE).name()) {
+		SERIALIZE_LOAD_ARCHIVE* ar = (SERIALIZE_LOAD_ARCHIVE*)archive;
+		ARCHIVEPTR_REGISTER_TYPE(ar, SkillTreeDatabase);
+		*ar&* this;
+		return true;
+	}
+	return false;
+}
+
+//************************************
+// Method:      afterSerialize
+// Description: 反序列化完成之后对 SkillTreeDatabase 中的对象进行加工处理
+// Access:      public 
+// Returns:     void
+// Author:      Sola丶小克(CairoLee)  2021/12/25 15:55
+//************************************ 
+void SkillTreeDatabase::afterSerialize() {
+
+}
+#endif // Pandas_YamlBlastCache_SkillTreeDatabase
+
 /**
  * Calculates base hp of player. Reference: http://irowiki.org/wiki/Max_HP
  * @param level: Base level of player

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -1131,7 +1131,9 @@ struct s_job_info {
 class JobDatabase : public TypesafeCachedYamlDatabase<uint16, s_job_info> {
 public:
 	JobDatabase() : TypesafeCachedYamlDatabase("JOB_STATS", 1) {
-
+#ifdef Pandas_YamlBlastCache_JobDatabase
+		this->supportSerialize = true;
+#endif // Pandas_YamlBlastCache_JobDatabase
 	}
 
 	const std::string getDefaultLocation();
@@ -1144,6 +1146,11 @@ public:
 	t_exp get_baseExp(uint16 job_id, uint32 level);
 	t_exp get_jobExp(uint16 job_id, uint32 level);
 	int32 get_maxWeight(uint16 job_id);
+
+#ifdef Pandas_YamlBlastCache_JobDatabase
+	bool doSerialize(const std::string& type, void* archive);
+	void afterSerialize();
+#endif // Pandas_YamlBlastCache_JobDatabase
 };
 
 extern JobDatabase job_db;
@@ -1739,5 +1746,40 @@ uint16 pc_level_penalty_mod( struct map_session_data* sd, e_penalty_type type, s
 bool pc_attendance_enabled();
 int32 pc_attendance_counter( struct map_session_data* sd );
 void pc_attendance_claim_reward( struct map_session_data* sd );
+
+
+#ifdef Pandas_YamlBlastCache_JobDatabase
+namespace boost {
+	namespace serialization {
+		// ======================================================================
+		// struct s_job_info
+		// ======================================================================
+		template <typename Archive>
+		void serialize(Archive& ar, struct s_job_info& t, const unsigned int version)
+		{
+			ar& t.base_hp;
+			ar& t.base_sp;
+			ar& t.base_ap;
+
+			ar& t.hp_factor;
+			ar& t.hp_multiplicator;
+			ar& t.sp_factor;
+			ar& t.max_weight_base;
+
+			ar& t.job_bonus;
+			ar& t.aspd_base;
+
+			ar& t.base_exp;
+			ar& t.job_exp;
+
+			ar& t.max_base_level;
+			ar& t.max_job_level;
+
+			ar& t.max_param;
+			//ar& t.noenter_map;						// JobDatabase 默认不会为其赋值, 暂时无需处理
+		}
+	} // namespace serialization
+} // namespace boost
+#endif // Pandas_YamlBlastCache_JobDatabase
 
 #endif /* PC_HPP */

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -1612,7 +1612,9 @@ struct s_skill_tree {
 class SkillTreeDatabase : public TypesafeYamlDatabase<uint16, s_skill_tree> {
 public:
 	SkillTreeDatabase() : TypesafeYamlDatabase("SKILL_TREE_DB", 1) {
-
+#ifdef Pandas_YamlBlastCache_SkillTreeDatabase
+		this->supportSerialize = true;
+#endif // Pandas_YamlBlastCache_SkillTreeDatabase
 	}
 
 	const std::string getDefaultLocation();
@@ -1621,6 +1623,11 @@ public:
 
 	// Additional
 	std::shared_ptr<s_skill_tree_entry> get_skill_data(int class_, uint16 skill_id);
+
+#ifdef Pandas_YamlBlastCache_SkillTreeDatabase
+	bool doSerialize(const std::string& type, void* archive);
+	void afterSerialize();
+#endif // Pandas_YamlBlastCache_SkillTreeDatabase
 };
 
 extern SkillTreeDatabase skill_tree_db;
@@ -1781,5 +1788,36 @@ namespace boost {
 	} // namespace serialization
 } // namespace boost
 #endif // Pandas_YamlBlastCache_JobDatabase
+
+
+#ifdef Pandas_YamlBlastCache_SkillTreeDatabase
+namespace boost {
+	namespace serialization {
+		// ======================================================================
+		// struct s_skill_tree_entry
+		// ======================================================================
+		template <typename Archive>
+		void serialize(Archive& ar, struct s_skill_tree_entry& t, const unsigned int version)
+		{
+			ar& t.skill_id;
+			ar& t.max_lv;
+			ar& t.baselv;
+			ar& t.joblv;
+			ar& t.need;
+			ar& t.exclude_inherit;
+		}
+
+		// ======================================================================
+		// struct s_skill_tree
+		// ======================================================================
+		template <typename Archive>
+		void serialize(Archive& ar, struct s_skill_tree& t, const unsigned int version)
+		{
+			ar& t.inherit_job;
+			ar& t.skills;
+		}
+	} // namespace serialization
+} // namespace boost
+#endif // Pandas_YamlBlastCache_SkillTreeDatabase
 
 #endif /* PC_HPP */

--- a/src/map/quest.hpp
+++ b/src/map/quest.hpp
@@ -58,15 +58,6 @@ enum e_quest_check_type : uint8 {
 };
 
 class QuestDatabase : public TypesafeYamlDatabase<uint32, s_quest_db> {
-#ifdef Pandas_YamlBlastCache_QuestDatabase
-private:
-	friend class boost::serialization::access;
-
-	template <typename Archive>
-	void serialize(Archive& ar, const unsigned int version) {
-		ar& boost::serialization::base_object<TypesafeYamlDatabase<uint32, s_quest_db>>(*this);
-	}
-#endif // Pandas_YamlBlastCache_QuestDatabase
 public:
 	QuestDatabase() : TypesafeYamlDatabase("QUEST_DB", 2, 1) {
 #ifdef Pandas_YamlBlastCache_QuestDatabase

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -311,15 +311,6 @@ struct s_skill_db {
 };
 
 class SkillDatabase : public TypesafeCachedYamlDatabase <uint16, s_skill_db> {
-#ifdef Pandas_YamlBlastCache_SkillDatabase
-private:
-	friend class boost::serialization::access;
-
-	template <typename Archive>
-	void serialize(Archive& ar, const unsigned int version) {
-		ar& boost::serialization::base_object<TypesafeCachedYamlDatabase<uint16, s_skill_db>>(*this);
-	}
-#endif // Pandas_YamlBlastCache_SkillDatabase
 public:
 	SkillDatabase() : TypesafeCachedYamlDatabase("SKILL_DB", 2, 1) {
 #ifdef Pandas_YamlBlastCache_SkillDatabase


### PR DESCRIPTION
在最近 rAthena 的调整中已经将职业数据库和技能树数据库从 txt 调整为 yml，因此疾风缓存也支持他们以便重点提高 DEBUG 模式下的程序启动速度

![image](https://user-images.githubusercontent.com/4458917/147383862-76a7a33b-4594-4acc-83d3-680e9dea228d.png)
