### PR TITLE
修正获取道具分组的随机算法权重不符合预期的问题 (感谢 "红狐狸" 提醒)

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -934,6 +934,15 @@
 	#ifdef Pandas_Struct_Status_Change_Cloak_Reverting
 		#define Pandas_Fix_Cloak_Status_Baffling
 	#endif // Pandas_Struct_Status_Change_Cloak_Reverting
+
+	// 修正获取道具分组的随机算法权重不符合预期的问题 [Sola丶小克]
+	// 所有最终使用 item_group_db.yml 数据的指令函数 (比如 getrandgroupitem 等)
+	// 最后都会经过 itemdb.cpp 中的 get_random_itemsubgroup 来获取随机物品
+	// 该函数的实现并不严谨, 随机出来的物品概率与 doc/item_group.txt 的描述不符合
+	// 这可能导致很多卡片或者道具过多流入到市场, 打破游戏平衡
+	//
+	// 感谢 "红狐狸" 提醒此问题
+	#define Pandas_Fix_GetRandom_ItemSubGroup_Algorithm
 #endif // Pandas_Bugfix
 
 // ============================================================================

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -1514,6 +1514,7 @@ int itemdb_searchname_array(struct item_data** data, int size, const char *str)
 }
 
 std::shared_ptr<s_item_group_entry> get_random_itemsubgroup(std::shared_ptr<s_item_group_random> random) {
+#ifndef Pandas_Fix_GetRandom_ItemSubGroup_Algorithm
 	if (random == nullptr)
 		return nullptr;
 
@@ -1525,6 +1526,29 @@ std::shared_ptr<s_item_group_entry> get_random_itemsubgroup(std::shared_ptr<s_it
 	}
 
 	return util::umap_random(random->data);
+#else
+	if (random == nullptr || random->data.size() == 0)
+		return nullptr;
+
+	uint32 randNum = rnd() % random->total_rate;
+
+	uint32 start = 0;
+	uint32 end = 0;
+
+	for (const auto& entry : random->data) {
+		if (entry.second->rate == 0) {
+			continue;
+		}
+
+		end = start + entry.second->rate;
+		if (start <= randNum && randNum < end) {
+			return entry.second;
+		}
+		start = end;
+	}
+
+	return nullptr;
+#endif // Pandas_Fix_GetRandom_ItemSubGroup_Algorithm
 }
 
 /**


### PR DESCRIPTION
## 故障描述

在 rathena 默认的 `get_random_itemsubgroup` 函数的随机算法存在问题，无法与 `doc\item_group.txt` 的表述一致。这可能会导致 GM 精心设计的宝箱物品权重无法正常发挥作用。

## 测试方法

- 将 501 - 507 的全部道具重量改成 0（方便测试）
- 修改 `db/re/item_group_db.yml` 中 `ACIDBOMB_10_BOX` 的分组内容为如下

```
  - Group: ACIDBOMB_10_BOX
    SubGroups:
      - SubGroup: 0
        List:
          - Item: Green_Potion
          - Item: Red_Herb
      - SubGroup: 1
        List:
          - Item: Red_Potion
            Rate: 1
          - Item: Orange_Potion
            Rate: 2500
          - Item: Yellow_Potion
            Rate: 2500
          - Item: White_Potion
            Rate: 2500
          - Item: Blue_Potion
            Rate: 2500
```

- 将以下脚本保存并加载到游戏中

```
prontera,150,150,4	script	tester	123,{
	atcommand("@itemreset");
	freeloop(1);
	for (.@round = 0; .@round < 10; .@round++) {
		for (.@i = 0; .@i < 1000; .@i++) {
			getgroupitem(IG_Acidbomb_10_Box);
		}
		sleep2 5;
	}
	end;
}
```

- 使用 `@tonpc tester` 飞往 npc 所在位置
- 与 NPC 对话（中间会卡住很久，耐心等待）
- 最终观察背包中的物品数量分布情况

## 修正前后对比

根据我们在 `db/re/item_group_db.yml` 的配置预期：
- 红色药水的概率应该是 1/10001
- 绿色药水和红色药草由于在 SubGroup 0 号组因此 100%出现
- 剩下的其他的四款药水概率均等。

但实际情况是修正之前经过测试三次，红色药水的出现概率接近 6/1000，这远超我们预期。

修正之后概率更加接近预设，甚至有时候一万个都出不来一个红色药水。

![画板](https://user-images.githubusercontent.com/4458917/148670196-a0a615c8-11ef-49b3-a37a-6e528b47866f.png)

