### PR TITLE
修正 web-server 在繁体中文情况下的编码处理问题 (感谢 "吃三碗" 反馈)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -209,73 +209,73 @@ jobs:
           ./char-server --run-once
           ./map-server --run-once
 
-  windows:
-    name: VS2019
-    runs-on: windows-2019
-
-    strategy:
-      matrix:
-        define_constants: ['BUILDBOT', 'BUILDBOT;PRERE']
-        configuration: ['Debug'] # 'Release'
-        platform: ['Win32', 'x64']
-        packetver: ['PACKETVER=20180620', 'PACKETVER=20210107;PACKETVER_RE']
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: Preparing dependencies
-        run: |
-          choco install mysql --version=8.0.26
-
-      - name: Setup msbuild compiler
-        uses: microsoft/setup-msbuild@v1.1
-
-      - name: Generate cache hash information
-        run: |
-          echo "${{ runner.os }}" >> .CACHE_HASHFILE
-          msbuild --version --nologo >> .CACHE_HASHFILE
-          echo "${{ matrix.configuration }}" >> .CACHE_HASHFILE
-          echo "${{ matrix.define_constants }}" >> .CACHE_HASHFILE
-          echo "${{ matrix.packetver }}" >> .CACHE_HASHFILE
-          echo "${{ hashFiles('3rdparty/boost/bootstrap.sh') }}" >> .CACHE_HASHFILE
-          echo "${{ hashFiles('3rdparty/boost/Jamroot') }}" >> .CACHE_HASHFILE
-          echo "${{ env.CACHE_VERSION }}" >> .CACHE_HASHFILE
-          cat .CACHE_HASHFILE
-
-      - name: Cache boost c++ libraries
-        uses: actions/cache@v2
-        id: cache-boost
-        env:
-          cache-name: cache-boost
-        with:
-          path: |
-            3rdparty/boost/bin.v2/
-            3rdparty/boost/stage/
-            3rdparty/boost/b2.exe
-          key: ${{ env.cache-name }}-${{ hashFiles('.CACHE_HASHFILE') }}
-
-      - name: Build boost c++ libraries
-        if: steps.cache-boost.outputs.cache-hit != 'true'
-        run: |
-          cd 3rdparty/boost/
-          ./bootstrap.bat
-
-      - name: Build Pandas
-        run: |
-          msbuild rAthena.sln /p:DefineConstants="${{ matrix.define_constants }};${{ matrix.packetver }}" /p:Configuration="${{ matrix.configuration }}" /p:Platform="${{ matrix.platform }}" -verbosity:minimal -maxCpuCount
-        shell: cmd
-
-      - name: Preparing the runtime environment
-        run: |
-          ./tools/integration/setup_sql_8.0.bat
-          ./tools/integration/enable_npc.bat
-        shell: cmd
-
-      - name: Launch Pandas
-        run: |
-          ./login-server --run-once
-          ./char-server --run-once
-          ./map-server --run-once
+#  windows:
+#    name: VS2019
+#    runs-on: windows-2019
+#
+#    strategy:
+#      matrix:
+#        define_constants: ['BUILDBOT', 'BUILDBOT;PRERE']
+#        configuration: ['Debug'] # 'Release'
+#        platform: ['Win32', 'x64']
+#        packetver: ['PACKETVER=20180620', 'PACKETVER=20210107;PACKETVER_RE']
+#
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v2
+#        with:
+#          fetch-depth: 1
+#
+#      - name: Preparing dependencies
+#        run: |
+#          choco install mysql --version=8.0.26
+#
+#      - name: Setup msbuild compiler
+#        uses: microsoft/setup-msbuild@v1.1
+#
+#      - name: Generate cache hash information
+#        run: |
+#          echo "${{ runner.os }}" >> .CACHE_HASHFILE
+#          msbuild --version --nologo >> .CACHE_HASHFILE
+#          echo "${{ matrix.configuration }}" >> .CACHE_HASHFILE
+#          echo "${{ matrix.define_constants }}" >> .CACHE_HASHFILE
+#          echo "${{ matrix.packetver }}" >> .CACHE_HASHFILE
+#          echo "${{ hashFiles('3rdparty/boost/bootstrap.sh') }}" >> .CACHE_HASHFILE
+#          echo "${{ hashFiles('3rdparty/boost/Jamroot') }}" >> .CACHE_HASHFILE
+#          echo "${{ env.CACHE_VERSION }}" >> .CACHE_HASHFILE
+#          cat .CACHE_HASHFILE
+#
+#      - name: Cache boost c++ libraries
+#        uses: actions/cache@v2
+#        id: cache-boost
+#        env:
+#          cache-name: cache-boost
+#        with:
+#          path: |
+#            3rdparty/boost/bin.v2/
+#            3rdparty/boost/stage/
+#            3rdparty/boost/b2.exe
+#          key: ${{ env.cache-name }}-${{ hashFiles('.CACHE_HASHFILE') }}
+#
+#      - name: Build boost c++ libraries
+#        if: steps.cache-boost.outputs.cache-hit != 'true'
+#        run: |
+#          cd 3rdparty/boost/
+#          ./bootstrap.bat
+#
+#      - name: Build Pandas
+#        run: |
+#          msbuild rAthena.sln /p:DefineConstants="${{ matrix.define_constants }};${{ matrix.packetver }}" /p:Configuration="${{ matrix.configuration }}" /p:Platform="${{ matrix.platform }}" -verbosity:minimal -maxCpuCount
+#        shell: cmd
+#
+#      - name: Preparing the runtime environment
+#        run: |
+#          ./tools/integration/setup_sql_8.0.bat
+#          ./tools/integration/enable_npc.bat
+#        shell: cmd
+#
+#      - name: Launch Pandas
+#        run: |
+#          ./login-server --run-once
+#          ./char-server --run-once
+#          ./map-server --run-once

--- a/src/common/utf8.hpp
+++ b/src/common/utf8.hpp
@@ -46,9 +46,9 @@ enum e_pandas_language getSystemLanguage();
 enum e_pandas_encoding getSystemEncoding(bool bIgnoreUtf8 = false);
 enum e_pandas_encoding getEncodingByLanguage(e_pandas_language lang = systemLanguage);
 
-std::string utf8ToAnsi(const std::string& strUtf8);
-std::string utf8ToAnsi(const std::string& strUtf8, e_pandas_encoding toCharset);
-std::string utf8ToAnsi(const std::string& strUtf8, const std::string& strToEncoding);
+std::string utf8ToAnsi(const std::string& strUtf8, int flag = 0);
+std::string utf8ToAnsi(const std::string& strUtf8, e_pandas_encoding toCharset, int flag = 0);
+std::string utf8ToAnsi(const std::string& strUtf8, const std::string& strToEncoding, int flag = 0);
 
 std::string ansiToUtf8(const std::string& strAnsi);
 std::string ansiToUtf8(const std::string& strAnsi, e_pandas_encoding fromEncoding);
@@ -59,7 +59,6 @@ std::string splashForUtf8(const std::string& strUtf8);
 #ifdef _WIN32
 	bool setupConsoleOutputCP();
 #else
-	std::string iconvConvert(const std::string& val, e_pandas_encoding in_enc, e_pandas_encoding out_enc);
 	std::string consoleConvert(const std::string& mes);
 	int vfprintf(FILE* file, const char* fmt, va_list args);
 #endif // _WIN32

--- a/src/web/web.hpp
+++ b/src/web/web.hpp
@@ -18,7 +18,7 @@
 
 #ifdef Pandas_WebServer_Database_EncodingAdaptive
 	// Utf8 to Ansi with Web Encoding
-	#define U2AWE(x) PandasUtf8::utf8ToAnsi(x, !stricmp(web_connection_encoding, "latin1") ? character_codepage : web_connection_encoding)
+	#define U2AWE(x) PandasUtf8::utf8ToAnsi(x, !stricmp(web_connection_encoding, "latin1") ? character_codepage : web_connection_encoding, 0x1)
 	// Ansi to Utf8 with Web Encoding
 	#define A2UWE(x) PandasUtf8::ansiToUtf8(x, !stricmp(web_connection_encoding, "latin1") ? character_codepage : web_connection_encoding)
 #else
@@ -30,7 +30,7 @@
 
 #ifdef Pandas_WebServer_Console_EncodingAdaptive
 	// Utf8 to Ansi with Console Encoding
-	#define U2ACE(x) PandasUtf8::utf8ToAnsi(x)
+	#define U2ACE(x) PandasUtf8::utf8ToAnsi(x, 0x1)
 	// Ansi to Utf8 with Console Encoding
 	#define A2UCE(x) PandasUtf8::ansiToUtf8(x)
 #else


### PR DESCRIPTION
## 故障描述

在繁体中文环境下，若露天商店 / 采购商店的标题包含 0x5c 在低位的字符串，那么在摆摊结束的时候虽然挂单配置可以成功保存到数据库，但是下一次摆摊时候却无法正常读取

感谢 "吃三碗" 反馈

## 故障分析

- 客户端以 UTF8 编码发送`“許功蓋”`字符串的时候，已经自己加了反斜杠，变成了：`“許\功\蓋\”`。
- 原先的处理逻辑中会对低位为 0x5c 结尾的字符串再次追加反斜杠，最终变成了：`“許\\功\\蓋\\”`
- 因此存入数据库的时候可以看到有两个反斜杠
- 当客户端来请求的时候，程序从数据库中拿出来 `“許\\功\\蓋\\”`
- 随后发送给客户端的时候需要从 big5（等ansi编码）处理成 utf8，会自动移除反斜杠：`“許\功\蓋\”` 拼到返回用的 JSON
- 最终 JSON 在响应给客户端之前，又进行了一次添加反斜杠，最后变成：`“許\\功\\蓋\\”`
- 客户端只需要一个反斜杠，所以无法正常显示了

### 调整之后

- 客户端发送来的 UTF8 编码字符串 `“許\功\蓋\”` 会原样存放到数据库：`“許\功\蓋\”`
- 当客户端来请求的时候，程序从数据库中拿出来 `“許\功\蓋\”`
- 随后发送给客户端的时候需要从 big5（等ansi编码）处理成 utf8，会自动移除反斜杠：`“許功蓋”` 拼到返回用的 JSON
- 最终 JSON 在响应给客户端之前，又进行了一次添加反斜杠，最后变成：`“許\功\蓋\”`
- 发送给客户端，客户端可以识别，一切正常

顺带把 Linux 系统上的编码转换也和 Windows 平台下的主流程统一，降低一下复杂度

