### PR TITLE
修正生成内存泄露日志文件时程序崩溃的问题

### DIFF
--- a/src/common/utf8.cpp
+++ b/src/common/utf8.cpp
@@ -829,7 +829,8 @@ enum e_file_charsetmode fmode(std::ifstream& ifs) {
 //************************************
 FILE* fopen(const char* _FileName, const char* _Mode) {
 	// 若当前打开文件的模式已经是二进制, 那么直接调用 fopen 并返回
-	if (strchr(_Mode, 'b')) {
+	// 若当前打开文件的模式包含 Write 或者是 Append 模式, 那么也直接调用 fopen 并返回
+	if (strchr(_Mode, 'b') || strchr(_Mode, 'w') || strchr(_Mode, 'a')) {
 		return ::fopen(_FileName, _Mode);
 	}
 


### PR DESCRIPTION
如果程序运行过程中刚好出现了内存泄漏，那么在退出的时候会尝试生成一个 leaks 文件
此时 utf8.cpp 中的 fopen 预处理函数不应该对打开模式进行加工（不应该处理任何计划要进行写操作的文件）