### PR TITLE
实现 OnPCHarmedExpress 实时事件, 当玩家受到伤害并即将进行结算时触发 [人鱼姬的思念]

### DIFF
--- a/doc/pandas_events.txt
+++ b/doc/pandas_events.txt
@@ -1021,11 +1021,11 @@
 		例子:
 		----------------
 		if ((@attack_damage_flag & BF_MAGIC) == BF_MAGIC) {
-			dispbottom "这是一次魔法攻击";
+			dispbottom "我发起了一次魔法攻击";
 		}
 		
 		if ((@attack_damage_flag & (BF_MAGIC|BF_LONG)) == (BF_MAGIC|BF_LONG)) {
-			dispbottom "这是一次远距离魔法攻击";
+			dispbottom "我发起了一次远距离魔法攻击";
 		}
 		
 	@attack_damage_skillid		本次攻击使用的技能编号 (若为 0 则表示普通攻击)
@@ -1035,6 +1035,69 @@
 
 注意事项:
 	只有即将发生伤害时才会触发此事件, 若为 MISS 则不触发此事件.
+	
+	假如攻击者和被攻击者都是玩家, 并且在服务器中除了使用 OnPCHarmedExpress 之外
+	还使用到了 OnPCAttackExpress 事件, 两个事件都对伤害进行调整的情况下,
+	原始伤害会先经过被攻击者的 OnPCHarmedExpress 事件处理,
+	再将 OnPCHarmedExpress 修改后的伤害, 发给攻击者的 OnPCAttackExpress 事件处理.
+
+性能警告:
+	全服建议最多只有一个 NPC 负责处理此事件.
+	全服在线玩家的任意一次实际造成伤害的攻击都将触发此事件,
+	因此请不要在事件中进行耗时操作.
+
+--------------------------------------------------------------
+
+*OnPCHarmedExpress:
+
+当玩家受到伤害并即将进行结算时触发实时事件 [人鱼姬的思念]
+
+事件关联:
+	关联到受到伤害的玩家
+	如果是宠物/生命体/佣兵/元素则直接关联到其主人
+
+携带参数:
+	@harmed_target_type			被攻击者的类型
+	@harmed_target_gid			被攻击者的游戏单位编号 (若是玩家则返回账号编号)
+	
+	@harmed_src_type			攻击者的类型
+	@harmed_src_gid				攻击者的游戏单位编号 (若是玩家则返回账号编号)
+	@harmed_src_mobid			攻击者的魔物编号 (若是不是魔物则返回 0)
+
+	@harmed_damage_flag			本次攻击的伤害类型 (位运算)
+		按攻击范围:
+			BF_SHORT:			近距离攻击
+			BF_LONG:			远距离攻击
+		按攻击类型:
+			BF_WEAPON:			武器攻击
+			BF_MAGIC:			魔法攻击
+			BF_MISC:			混合攻击
+		按技能类型:
+			BF_NORMAL:			普通攻击
+			BF_SKILL:			技能攻击
+		
+		例子:
+		----------------
+		if ((@harmed_damage_flag & BF_MAGIC) == BF_MAGIC) {
+			dispbottom "我受到了一次魔法攻击";
+		}
+		
+		if ((@harmed_damage_flag & (BF_MAGIC|BF_LONG)) == (BF_MAGIC|BF_LONG)) {
+			dispbottom "我受到了一次远距离魔法攻击";
+		}
+		
+	@harmed_damage_skillid		本次攻击使用的技能编号 (若为 0 则表示普通攻击)
+	@harmed_damage_skilllv		本次攻击使用的技能等级
+	@harmed_damage_right		本次攻击右手武器造成的伤害值 (该值可被修改)
+	@harmed_damage_left			本次攻击左手武器造成的伤害值 (该值可被修改)
+
+注意事项:
+	只有即将发生伤害时才会触发此事件, 若为 MISS 则不触发此事件.
+	
+	假如攻击者和被攻击者都是玩家, 并且在服务器中除了使用 OnPCHarmedExpress 之外
+	还使用到了 OnPCAttackExpress 事件, 两个事件都对伤害进行调整的情况下,
+	原始伤害会先经过被攻击者的 OnPCHarmedExpress 事件处理,
+	再将 OnPCHarmedExpress 修改后的伤害, 发给攻击者的 OnPCAttackExpress 事件处理.
 
 性能警告:
 	全服建议最多只有一个 NPC 负责处理此事件.

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1483,6 +1483,11 @@
 		// 事件类型: Express / 事件名称: OnPCTalkExpress
 		// 常量名称: NPCX_PC_TALK / 变量名称: pc_talk_express_name
 		#define Pandas_NpcExpress_PC_TALK
+
+		// 当玩家受到伤害并即将进行结算时触发实时事件 [人鱼姬的思念]
+		// 事件类型: Express / 事件名称: OnPCHarmedExpress
+		// 常量名称: NPCX_PCHARMED / 变量名称: pcharmed_express_name
+		#define Pandas_NpcExpress_PCHARMED
 		// PYHELP - NPCEVENT - INSERT POINT - <Section 13>
 	#endif // Pandas_ScriptEngine_Express
 	

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9054,6 +9054,48 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 	}
 #endif // Pandas_Bonus3_bFinalAddClass
 
+#ifdef Pandas_NpcExpress_PCHARMED
+	if (src && target && damage > 0) {
+		// 负责执行事件的玩家对象 (事件执行者)
+		struct map_session_data* esd = nullptr;
+
+		// 若受伤害者不是玩家单位, 那么试图获取受伤害者的主人
+		if (target->type != BL_PC) {
+			struct block_list* mbl = nullptr;
+			mbl = battle_get_master(target);
+			if (mbl != nullptr && mbl->type == BL_PC) {
+				esd = BL_CAST(BL_PC, mbl);
+			}
+		}
+		
+		// 若负责执行事件的玩家对象依然没被指定
+		// 且受伤害者是一个玩家单位, 那么将受伤害者直接指定成负责执行事件的玩家
+		if (!esd && target->type == BL_PC) {
+			esd = (TBL_PC*)target;
+		}
+
+		// 若到这里还没有一个合适的事件执行者则不需要触发事件
+		if (esd) {
+			pc_setreg(esd, add_str("@harmed_target_type"), target->type);
+			pc_setreg(esd, add_str("@harmed_target_gid"), target->id);
+			
+			pc_setreg(esd, add_str("@harmed_src_type"), src->type);
+			pc_setreg(esd, add_str("@harmed_src_gid"), src->id);
+			pc_setreg(esd, add_str("@harmed_src_mobid"), (src->type == BL_MOB ? ((TBL_MOB*)src)->mob_id : 0));
+			
+			pc_setreg(esd, add_str("@harmed_damage_flag"), wd.flag);
+			pc_setreg(esd, add_str("@harmed_damage_skillid"), 0);
+			pc_setreg(esd, add_str("@harmed_damage_skilllv"), 0);
+			pc_setreg(esd, add_str("@harmed_damage_right"), wd.damage);
+			pc_setreg(esd, add_str("@harmed_damage_left"), wd.damage2);
+			npc_script_event(esd, NPCX_PCHARMED);
+			wd.damage = (int)cap_value(pc_readreg(esd, add_str("@harmed_damage_right")), INT_MIN, INT_MAX);
+			wd.damage2 = (int)cap_value(pc_readreg(esd, add_str("@harmed_damage_left")), INT_MIN, INT_MAX);
+			damage = wd.damage + wd.damage2;
+		}
+	}
+#endif // Pandas_NpcExpress_PCHARMED
+
 #ifdef Pandas_NpcExpress_PCATTACK
 	if (src && target && damage > 0) {
 		// 负责执行事件的玩家对象 (事件执行者)

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -6345,6 +6345,10 @@ bool npc_event_is_express(enum npce_event eventtype) {
 #ifdef Pandas_NpcExpress_PC_TALK
 		NPCX_PC_TALK,	// pc_talk_express_name	// OnPCTalkExpress		// 当玩家往聊天框发送信息时触发实时事件 [人鱼姬的思念]
 #endif // Pandas_NpcExpress_PC_TALK
+
+#ifdef Pandas_NpcExpress_PCHARMED
+		NPCX_PCHARMED,	// pcharmed_express_name	// OnPCHarmedExpress		// 当玩家受到伤害并即将进行结算时触发实时事件 [人鱼姬的思念]
+#endif // Pandas_NpcExpress_PCHARMED
 		// PYHELP - NPCEVENT - INSERT POINT - <Section 19>
 	};
 
@@ -6779,6 +6783,11 @@ const char *npc_get_script_event_name(int npce_index)
 	case NPCX_PC_TALK:
 		return script_config.pc_talk_express_name;	// OnPCTalkExpress		// 当玩家往聊天框发送信息时触发实时事件 [人鱼姬的思念]
 #endif // Pandas_NpcExpress_PC_TALK
+
+#ifdef Pandas_NpcExpress_PCHARMED
+	case NPCX_PCHARMED:
+		return script_config.pcharmed_express_name;	// OnPCHarmedExpress		// 当玩家受到伤害并即将进行结算时触发实时事件 [人鱼姬的思念]
+#endif // Pandas_NpcExpress_PCHARMED
 	// PYHELP - NPCEVENT - INSERT POINT - <Section 15>
 
 	default:

--- a/src/map/npc.hpp
+++ b/src/map/npc.hpp
@@ -2467,8 +2467,12 @@ enum npce_event : uint8 {
 #endif // Pandas_NpcExpress_MER_LEAVE
 
 #ifdef Pandas_NpcExpress_PC_TALK
-		NPCX_PC_TALK,	// pc_talk_express_name	// OnPCTalkExpress		// 当玩家往聊天框发送信息时触发实时事件 [人鱼姬的思念]
+	NPCX_PC_TALK,	// pc_talk_express_name	// OnPCTalkExpress		// 当玩家往聊天框发送信息时触发实时事件 [人鱼姬的思念]
 #endif // Pandas_NpcExpress_PC_TALK
+
+#ifdef Pandas_NpcExpress_PCHARMED
+	NPCX_PCHARMED,	// pcharmed_express_name	// OnPCHarmedExpress		// 当玩家受到伤害并即将进行结算时触发实时事件 [人鱼姬的思念]
+#endif // Pandas_NpcExpress_PCHARMED
 	// PYHELP - NPCEVENT - INSERT POINT - <Section 14>
 	NPCE_MAX
 };

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -468,6 +468,10 @@ struct Script_Config script_config = {
 #ifdef Pandas_NpcExpress_PC_TALK
 		"OnPCTalkExpress",	// NPCX_PC_TALK		// pc_talk_express_name	// 当玩家往聊天框发送信息时触发实时事件 [人鱼姬的思念]
 #endif // Pandas_NpcExpress_PC_TALK
+
+#ifdef Pandas_NpcExpress_PCHARMED
+	"OnPCHarmedExpress",	// NPCX_PCHARMED		// pcharmed_express_name	// 当玩家受到伤害并即将进行结算时触发实时事件 [人鱼姬的思念]
+#endif // Pandas_NpcExpress_PCHARMED
 	// PYHELP - NPCEVENT - INSERT POINT - <Section 17>
 
 	// NPC related

--- a/src/map/script.hpp
+++ b/src/map/script.hpp
@@ -344,6 +344,10 @@ struct Script_Config {
 #ifdef Pandas_NpcExpress_PC_TALK
 	const char* pc_talk_express_name;	// NPCX_PC_TALK	// OnPCTalkExpress	// 当玩家往聊天框发送信息时触发实时事件 [人鱼姬的思念]
 #endif // Pandas_NpcExpress_PC_TALK
+
+#ifdef Pandas_NpcExpress_PCHARMED
+	const char* pcharmed_express_name;	// NPCX_PCHARMED	// OnPCHarmedExpress	// 当玩家受到伤害并即将进行结算时触发实时事件 [人鱼姬的思念]
+#endif // Pandas_NpcExpress_PCHARMED
 	// PYHELP - NPCEVENT - INSERT POINT - <Section 16>
 
 	// NPC related

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -201,6 +201,10 @@
 #ifdef Pandas_NpcExpress_PC_TALK
 	export_constant(NPCX_PC_TALK);	// pc_talk_express_name	// OnPCTalkExpress		// 当玩家往聊天框发送信息时触发实时事件 [人鱼姬的思念]
 #endif // Pandas_NpcExpress_PC_TALK
+
+#ifdef Pandas_NpcExpress_PCHARMED
+	export_constant(NPCX_PCHARMED);	// pcharmed_express_name	// OnPCHarmedExpress		// 当玩家受到伤害并即将进行结算时触发实时事件 [人鱼姬的思念]
+#endif // Pandas_NpcExpress_PCHARMED
 	// PYHELP - NPCEVENT - INSERT POINT - <Section 18>
 #endif // Pandas_ScriptCommands
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -3850,6 +3850,48 @@ int64 skill_attack (int attack_type, struct block_list* src, struct block_list *
 	}
 #endif // Pandas_Bonus3_bFinalAddClass
 
+#ifdef Pandas_NpcExpress_PCHARMED
+	if (src && bl && damage > 0) {
+		// 负责执行事件的玩家对象 (事件执行者)
+		struct map_session_data* esd = nullptr;
+
+		// 若受伤害者不是玩家单位, 那么试图获取受伤害者的主人
+		if (bl->type != BL_PC) {
+			struct block_list* mbl = nullptr;
+			mbl = battle_get_master(bl);
+			if (mbl != nullptr && mbl->type == BL_PC) {
+				esd = BL_CAST(BL_PC, mbl);
+			}
+		}
+		
+		// 若负责执行事件的玩家对象依然没被指定
+		// 且受伤害者是一个玩家单位, 那么将受伤害者直接指定成负责执行事件的玩家
+		if (!esd && bl->type == BL_PC) {
+			esd = (TBL_PC*)bl;
+		}
+
+		// 若到这里还没有一个合适的事件执行者则不需要触发事件
+		if (esd) {
+			pc_setreg(esd, add_str("@harmed_target_type"), bl->type);
+			pc_setreg(esd, add_str("@harmed_target_gid"), bl->id);
+			
+			pc_setreg(esd, add_str("@harmed_src_type"), src->type);
+			pc_setreg(esd, add_str("@harmed_src_gid"), src->id);
+			pc_setreg(esd, add_str("@harmed_src_mobid"), (src->type == BL_MOB ? ((TBL_MOB*)src)->mob_id : 0));
+			
+			pc_setreg(esd, add_str("@harmed_damage_flag"), dmg.flag);
+			pc_setreg(esd, add_str("@harmed_damage_skillid"), skill_id);
+			pc_setreg(esd, add_str("@harmed_damage_skilllv"), skill_lv);
+			pc_setreg(esd, add_str("@harmed_damage_right"), dmg.damage);
+			pc_setreg(esd, add_str("@harmed_damage_left"), dmg.damage2);
+			npc_script_event(tsd, NPCX_PCHARMED);
+			dmg.damage = (int)cap_value(pc_readreg(esd, add_str("@harmed_damage_right")), INT_MIN, INT_MAX);
+			dmg.damage2 = (int)cap_value(pc_readreg(esd, add_str("@harmed_damage_left")), INT_MIN, INT_MAX);
+			damage = dmg.damage + dmg.damage2;
+		}
+	}
+#endif // Pandas_NpcExpress_PCHARMED
+
 #ifdef Pandas_NpcExpress_PCATTACK
 	if (src && bl && damage > 0) {
 		// 负责执行事件的玩家对象 (事件执行者)


### PR DESCRIPTION
--------------------------------------------------------------

*OnPCHarmedExpress:

当玩家受到伤害并即将进行结算时触发实时事件 [人鱼姬的思念]

事件关联:
	关联到受到伤害的玩家
	如果是宠物/生命体/佣兵/元素则直接关联到其主人

携带参数:
	@harmed_target_type			被攻击者的类型
	@harmed_target_gid			被攻击者的游戏单位编号 (若是玩家则返回账号编号)
	
	@harmed_src_type			攻击者的类型
	@harmed_src_gid				攻击者的游戏单位编号 (若是玩家则返回账号编号)
	@harmed_src_mobid			攻击者的魔物编号 (若是不是魔物则返回 0)

	@harmed_damage_flag			本次攻击的伤害类型 (位运算)
		按攻击范围:
			BF_SHORT:			近距离攻击
			BF_LONG:			远距离攻击
		按攻击类型:
			BF_WEAPON:			武器攻击
			BF_MAGIC:			魔法攻击
			BF_MISC:			混合攻击
		按技能类型:
			BF_NORMAL:			普通攻击
			BF_SKILL:			技能攻击
		
		例子:
		----------------
		if ((@harmed_damage_flag & BF_MAGIC) == BF_MAGIC) {
			dispbottom "我受到了一次魔法攻击";
		}
		
		if ((@harmed_damage_flag & (BF_MAGIC|BF_LONG)) == (BF_MAGIC|BF_LONG)) {
			dispbottom "我受到了一次远距离魔法攻击";
		}
		
	@harmed_damage_skillid		本次攻击使用的技能编号 (若为 0 则表示普通攻击)
	@harmed_damage_skilllv		本次攻击使用的技能等级
	@harmed_damage_right		本次攻击右手武器造成的伤害值 (该值可被修改)
	@harmed_damage_left			本次攻击左手武器造成的伤害值 (该值可被修改)

注意事项:
	只有即将发生伤害时才会触发此事件, 若为 MISS 则不触发此事件.
	
	假如攻击者和被攻击者都是玩家, 并且在服务器中除了使用 OnPCHarmedExpress 之外
	还使用到了 OnPCAttackExpress 事件, 两个事件都对伤害进行调整的情况下,
	原始伤害会先经过被攻击者的 OnPCHarmedExpress 事件处理,
	再将 OnPCHarmedExpress 修改后的伤害, 发给攻击者的 OnPCAttackExpress 事件处理.

性能警告:
	全服建议最多只有一个 NPC 负责处理此事件.
	全服在线玩家的任意一次实际造成伤害的攻击都将触发此事件,
	因此请不要在事件中进行耗时操作.

--------------------------------------------------------------