### PR TITLE
修正 stylist 功能在花费金币时 zenylog 写入失败的情况

### DIFF
--- a/sql-files/composer/logs/upgrade_to_1.1.11_logs.sql
+++ b/sql-files/composer/logs/upgrade_to_1.1.11_logs.sql
@@ -14,3 +14,11 @@ ALTER TABLE `picklog`
 ALTER TABLE `zenylog`
 	MODIFY `type` enum('T','V','P','M','S','N','D','C','A','E','I','B','K','J') NOT NULL default 'S'
 ;
+
+-- -----------------------------------------------
+-- 在 zenylog 中额外添加个 X 类型
+-- -----------------------------------------------
+
+ALTER TABLE `zenylog`
+	MODIFY `type` enum('T','V','P','M','S','N','D','C','A','E','I','B','K','J','X') NOT NULL default 'S'
+;

--- a/sql-files/logs.sql
+++ b/sql-files/logs.sql
@@ -218,13 +218,14 @@ CREATE TABLE IF NOT EXISTS `picklog` (
 # (B)uying Store
 # Ban(K) Transactions
 # Barter Shop (J)
+# (X) Other
 
 CREATE TABLE IF NOT EXISTS `zenylog` (
   `id` int(11) NOT NULL auto_increment,
   `time` datetime NOT NULL,
   `char_id` int(11) NOT NULL default '0',
   `src_id` int(11) NOT NULL default '0',
-  `type` enum('T','V','P','M','S','N','D','C','A','E','I','B','K','J') NOT NULL default 'S',
+  `type` enum('T','V','P','M','S','N','D','C','A','E','I','B','K','J','X') NOT NULL default 'S',
   `amount` int(11) NOT NULL default '0',
   `map` varchar(11) NOT NULL default '',
   PRIMARY KEY  (`id`),


### PR DESCRIPTION
rAthena 在添加 stylist 功能的时候，忘记拓展 zenylog 数据库的金币花销类型，我们单独给他添加一下