### PR TITLE
修正玩家在重新计算技能树时的一处潜在崩溃

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2306,6 +2306,10 @@ void pc_calc_skilltree(struct map_session_data *sd)
 			if (!fail) {
 				std::shared_ptr<s_skill_db> skill = skill_db.find(skid);
 
+#ifdef Pandas_Crashfix_Prevent_NullPointer
+				if (!skill) continue;
+#endif // Pandas_Crashfix_Prevent_NullPointer
+
 				if (!sd->status.skill[sk_idx].lv && (
 					(skill->inf2[INF2_ISQUEST] && !battle_config.quest_skill_learn) ||
 					skill->inf2[INF2_ISWEDDING] ||


### PR DESCRIPTION
## 重现方法

- 关闭疾风缓存或确保已经汇入 #535 
- 先准备一个全技能的炼金术师职业（比如四转的 4259 也行）
- 角色退出，关闭服务器
- 修改 db/re/item_db_ect.yml 物品编号为 7135 （火烟瓶）的 AegisName 为其他内容
- 启动服务器
- 登录刚刚准备好的炼金术师角色，地图服务器崩溃
