### PR TITLE
修复检测邮件卡片初始值错误 (感谢 "SSBoyz" 指出)

### DIFF
--- a/src/map/mail.cpp
+++ b/src/map/mail.cpp
@@ -287,7 +287,7 @@ enum mail_attach_result mail_setitem(struct map_session_data *sd, short idx, uin
 		sd->mail.item[i].details.equip = sd->inventory.u.items_inventory[idx].equip;
 		sd->mail.item[i].details.equipSwitch = sd->inventory.u.items_inventory[idx].equipSwitch;
 
-		for (int j = sd->inventory_data[idx]->slots; j < MAX_SLOTS; j++)
+		for (int j = 0; j < MAX_SLOTS; j++)
 			sd->mail.item[i].details.card[j] = sd->inventory.u.items_inventory[idx].card[j];
 
 		for (int j = 0; j < MAX_ITEM_RDM_OPT; j++) {


### PR DESCRIPTION
### 重現方法
****
- 创建一件插入波利卡片的棉衬杉
- 使用 Rodex 寄出后会获得 Transmission has failed to inappropriate items. 的客户端讯息
- 创建一件未插入卡片的棉衬杉
- 使用 Rodex 寄出，可以成功寄出邮件。