### PR TITLE
默认禁止在角色、公会、队伍名称中使用单引号 (感谢 "ssboyz" 建议)

### DIFF
--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -301,7 +301,7 @@ char_name_option: 2
 // 为了配合熊猫模拟器将 char_name_option 默认值改为 2 的改动, 
 // 我们将 char_name_letters 的值改成了一些平时玩家不常用的特殊符号, 
 // 禁止在创建角色、队伍、公会名称时使用下列这些字符
-char_name_letters: \/:*?#@!
+char_name_letters: \/:*?#@!'
 
 // 根据角色的基础等级, 限制玩家删除角色
 //  0: 没有限制 (玩家可以删掉任何等级的角色)


### PR DESCRIPTION
- 角色、队伍、公会名称存在被 SQL 注入利用的风险，默认禁止单引号