### PR TITLE
修正 rAthena 在 status_change_start 引入的重算逻辑导致的一系列异常

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -980,6 +980,24 @@
 	// 修正使用 @showexp 指令后呈现的经验值数值会错误的问题 [Sola丶小克]
 	// 备注: 单次获得的经验超过 long 的有效阈值范围后就会溢出成负数, 但最新的有效经验值区间是 int64
 	#define Pandas_Fix_GainExp_Display_Overflow
+
+	// 修正 rAthena 在 status_change_start 引入的重算逻辑导致的一系列异常 [Sola丶小克]
+	// 主要包含以下两个情况:
+	// - 重算导致清空了 autospell 的防止多次执行, 在特殊构造下会导致死循环
+	//   - 将怒爆的 Cooldown 设置为 0 之后
+	//   - 穿戴一件具有 100% 触发怒爆的装备如: bonus5 bAutoSpellOnSkill,7,7,5,1000,0;
+	//   - 找个剑士使用怒爆, 则会直接导致崩溃
+	// - 重算导致在 autobonus 的 bonus script 中使用 sc_start 会导致能力重算事件被递归执行多次
+	//   - 在特殊情况下这会导致地图服务器因栈溢出而崩溃
+	//   - 让某个装备具备脚本: bonus5 bAutoSpell,20,3,1000,BF_WEAPON,1;
+	//   - 改造小青的幽魂道具 (编号: 19136) 让它脚本中的 autobonus 变成以下脚本:
+	//     - autobonus "{ sc_start SC_MONSTER_TRANSFORM,5000,1631; bonus bMatkRate,30; bonus bCritAtkRate,30; }",1000,5000,BF_WEAPON,"{ specialeffect2 EF_POTION_BERSERK; showscript "Eddga Power !"; }"; 
+	//     - autobonus "{ sc_start SC_MONSTER_TRANSFORM,5000,1631; bonus bMatkRate,30; bonus bCritAtkRate,30; bonus2 bIgnoreDefClassRate,Class_All,50; bonus2 bIgnoreMdefClassRate,Class_All,50;}", 1000, 5000, BF_MAGIC, "{ specialeffect2 EF_POTION_BERSERK; showscript "Eddga Power !"; }";
+	//   - 使用普通攻击, 可发现以下异常特征:
+	//     - 面板数据错乱
+	//     - 能力重算事件被多次重复递归调用
+	//     - 有概率的导致地图服务器堆栈溢出崩溃
+	#define Pandas_Fix_Status_Change_Start_Infinite_Recalculate_Status
 #endif // Pandas_Bugfix
 
 // ============================================================================

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12701,6 +12701,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 	if (sd) {
 		if (sd->pd)
 			pet_sc_check(sd, type); // Skotlex: Pet Status Effect Healing
+#ifndef Pandas_Fix_Status_Change_Start_Infinite_Recalculate_Status
 		switch (type) {
 			case SC_BERSERK:
 			case SC_MERC_HPUP:
@@ -12712,6 +12713,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 					status_calc_pc(sd, SCO_NONE);
 				break;
 		}
+#endif // Pandas_Fix_Status_Change_Start_Infinite_Recalculate_Status
 	}
 
 	// 1st thing to execute when loading status


### PR DESCRIPTION
主要包含以下两个情况:
- 重算导致清空了 autospell 的防止多次执行, 在特殊构造下会导致死循环
  - 将怒爆的 Cooldown 设置为 0 之后
  - 穿戴一件具有 100% 触发怒爆的装备如: bonus5 bAutoSpellOnSkill,7,7,5,1000,0;
  - 找个剑士使用怒爆, 则会直接导致崩溃
- 重算导致在 autobonus 的 bonus script 中使用 sc_start 会导致能力重算事件被递归执行多次
  - 在特殊情况下这会导致地图服务器因栈溢出而崩溃
  - 让某个装备具备脚本: bonus5 bAutoSpell,20,3,1000,BF_WEAPON,1;
  - 改造小青的幽魂道具 (编号: 19136) 让它脚本中的 autobonus 变成以下脚本:
    - autobonus "{ sc_start SC_MONSTER_TRANSFORM,5000,1631; bonus bMatkRate,30; bonus bCritAtkRate,30; }",1000,5000,BF_WEAPON,"{ specialeffect2 EF_POTION_BERSERK; showscript "Eddga Power !"; }"; 
    - autobonus "{ sc_start SC_MONSTER_TRANSFORM,5000,1631; bonus bMatkRate,30; bonus bCritAtkRate,30; bonus2 bIgnoreDefClassRate,Class_All,50; bonus2 bIgnoreMdefClassRate,Class_All,50;}", 1000, 5000, BF_MAGIC, "{ specialeffect2 EF_POTION_BERSERK; showscript "Eddga Power !"; }";
  - 使用普通攻击, 可发现以下异常特征:
    - 面板数据错乱
    - 能力重算事件被多次重复递归调用
    - 有概率的导致地图服务器堆栈溢出崩溃