### PR TITLE
修正 bonus3 bAddEffOnSkill 中 PC_BONUS_CHK_SC 带入检测参数错误的问题

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -998,6 +998,9 @@
 	//     - 能力重算事件被多次重复递归调用
 	//     - 有概率的导致地图服务器堆栈溢出崩溃
 	#define Pandas_Fix_Status_Change_Start_Infinite_Recalculate_Status
+
+	// 修正 bonus3 bAddEffOnSkill 中 PC_BONUS_CHK_SC 带入检测参数错误的问题 [Renee]
+	#define Pandas_Fix_bouns3_bAddEffOnSkill_PC_BONUS_CHK_SC_Error
 #endif // Pandas_Bugfix
 
 // ============================================================================

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -4934,7 +4934,11 @@ void pc_bonus3(struct map_session_data *sd,int type,int type2,int type3,int val)
 		break;
 
 	case SP_ADDEFF_ONSKILL: // bonus3 bAddEffOnSkill,sk,eff,n;
+#ifndef Pandas_Fix_bouns3_bAddEffOnSkill_PC_BONUS_CHK_SC_Error
 		PC_BONUS_CHK_SC(type2,SP_ADDEFF_ONSKILL);
+#else
+		PC_BONUS_CHK_SC(type3, SP_ADDEFF_ONSKILL);
+#endif // Pandas_Fix_bouns3_bAddEffOnSkill_PC_BONUS_CHK_SC_Error
 		if( sd->state.lr_flag != 2 )
 			pc_bonus_addeff_onskill(sd->addeff_onskill, (sc_type)type3, val, type2, ATF_TARGET, 0);
 		break;


### PR DESCRIPTION
使用 4547 卡片这种携带 bAddEffOnSkill 的道具时会出现一个检查报错，尝试用一个技能编号去检查是不是一个存在的 SC

感谢 "忘我" 反馈