### PR TITLE
修正客户端重置快捷键后 WEB 接口服务器没有删除对应记录的问题

### DIFF
--- a/src/web/userconfig_controller.cpp
+++ b/src/web/userconfig_controller.cpp
@@ -210,7 +210,10 @@ HANDLER_FUNC(userconfig_save) {
 			json data_from_db = json::parse(A2UWE(databuf));
 			json data_from_client = json::parse(req.get_file_value("data").content);
 
-			data_from_db.merge_patch_v2(data_from_client, false);
+			// 此处需要允许 null 节点对数据进行覆盖
+			// 否则当玩家在客户端中重置快捷键设置的时候, 会发送上来一个全部都为 null 的节点,
+			// 此时服务端忽略掉它们, 会导致玩家下次登录还会发现快捷键还在
+			data_from_db.merge_patch_v2(data_from_client, true);
 			data = U2AWE(data_from_db.dump(3));
 		}
 	}


### PR DESCRIPTION
## 测试步骤

- 客户端先给玩家设置快捷键
- 退出第一次客户端
- 再次登录后，打开快捷键设置界面，点击恢复默认
- 再次退出客户端
- 重新进入游戏

## 预期情况

- 快捷键处于默认状态

## 实际情况

- 快捷键处于重置为默认之前的状态