### PR TITLE
修正 reloadbarterdb 没有调用父类 clear 导致数据没被重置的问题

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -1176,6 +1176,7 @@ static int npc_reload_barters_sub(struct npc_data* nd, va_list args) {
 
 void BarterDatabase::clear() {
 	map_foreachnpc(npc_reload_barters_sub);
+	TypesafeYamlDatabase::clear();
 }
 #endif // Pandas_AtCommand_ReloadBarterDB
 


### PR DESCRIPTION
- 感谢 @Hong-Shin  发现此问题