### PR TITLE
修正倉庫存取事件打斷後 Alt + RightClick 快捷鍵失效和手推車物品無法拖曳情況

### DIFF
--- a/src/map/storage.cpp
+++ b/src/map/storage.cpp
@@ -373,6 +373,7 @@ void storage_storageadd(struct map_session_data* sd, struct s_storage *stor, int
 	else if (result == STORAGE_ADD_OK) {
 #ifdef Pandas_NpcFilter_STORAGE_ADD
 		if (npc_event_aide_storage_add(sd, stor, index, amount, TABLE_INVENTORY)) {
+			clif_storageitemremoved(sd, index, 0);
 			clif_dropitem(sd, index, 0);
 			return;
 		}
@@ -414,6 +415,7 @@ void storage_storageget(struct map_session_data *sd, struct s_storage *stor, int
 
 #ifdef Pandas_NpcFilter_STORAGE_DEL
 	if (npc_event_aide_storage_del(sd, stor, index, amount, TABLE_INVENTORY)) {
+		clif_storageitemremoved(sd, index, 0);
 		return;
 	}
 #endif // Pandas_NpcFilter_STORAGE_DEL
@@ -449,6 +451,8 @@ void storage_storageaddfromcart(struct map_session_data *sd, struct s_storage *s
 	else if (result == STORAGE_ADD_OK) {
 #ifdef Pandas_NpcFilter_STORAGE_ADD
 		if (npc_event_aide_storage_add(sd, stor, index, amount, TABLE_CART)) {
+			clif_storageitemremoved(sd, index, 0);
+			clif_cart_delitem(sd, index, 0);
 			return;
 		}
 #endif // Pandas_NpcFilter_STORAGE_ADD
@@ -494,6 +498,7 @@ void storage_storagegettocart(struct map_session_data* sd, struct s_storage *sto
 
 #ifdef Pandas_NpcFilter_STORAGE_DEL
 	if (npc_event_aide_storage_del(sd, stor, index, amount, TABLE_CART)) {
+		clif_storageitemremoved(sd, index, 0);
 		return;
 	}
 #endif // Pandas_NpcFilter_STORAGE_DEL
@@ -977,6 +982,7 @@ void storage_guild_storageadd(struct map_session_data* sd, int index, int amount
 
 #ifdef Pandas_NpcFilter_STORAGE_ADD
 	if (npc_event_aide_storage_add(sd, stor, index, amount, TABLE_INVENTORY)) {
+		clif_storageitemremoved(sd, index, 0);
 		clif_dropitem(sd, index, 0);
 		return;
 	}
@@ -1024,6 +1030,7 @@ void storage_guild_storageget(struct map_session_data* sd, int index, int amount
 
 #ifdef Pandas_NpcFilter_STORAGE_DEL
 	if (npc_event_aide_storage_del(sd, stor, index, amount, TABLE_INVENTORY)) {
+		clif_storageitemremoved(sd, index, 0);
 		return;
 	}
 #endif // Pandas_NpcFilter_STORAGE_DEL
@@ -1063,6 +1070,8 @@ void storage_guild_storageaddfromcart(struct map_session_data* sd, int index, in
 
 #ifdef Pandas_NpcFilter_STORAGE_ADD
 	if (npc_event_aide_storage_add(sd, stor, index, amount, TABLE_CART)) {
+		clif_storageitemremoved(sd, index, 0);
+		clif_cart_delitem(sd, index, 0);
 		return;
 	}
 #endif // Pandas_NpcFilter_STORAGE_ADD
@@ -1104,6 +1113,7 @@ void storage_guild_storagegettocart(struct map_session_data* sd, int index, int 
 
 #ifdef Pandas_NpcFilter_STORAGE_DEL
 	if (npc_event_aide_storage_del(sd, stor, index, amount, TABLE_CART)) {
+		clif_storageitemremoved(sd, index, 0);
 		return;
 	}
 #endif // Pandas_NpcFilter_STORAGE_DEL


### PR DESCRIPTION
熊貓模擬器社區版: v1.1.14
客戶端版本: 2021-11-17

修正以下二種情況

情況1: Alt + RightClick 快捷鍵失效

在 'OnPCStorageAddFilter'或 'OnPCStorageDelFilter' 事件中使用 'processhalt' 指令中斷.
使用 Alt + RightClick 快捷鍵在倉庫, 手推車, 背包三方面存入或取出道具時, 僅第一次點擊的道具能夠觸發腳本.

情況2: 手推車物品無法拖曳

在 'OnPCStorageAddFilter' 事件中使用 'processhalt' 指令中斷.
將 '指定的存取道具' 從手推車放入倉庫, 然後將其他任意道具從背包放入手推車或從手推車取回背包,
會發生手推車內的 '指定的存取道具' 無法拖曳的情況.