### PR TITLE
修正 UTF8-BOM 字符转换成 BIG5 时存在多余反斜杠的问题 (感谢 "DDWT", "jian916" 反馈)

### DIFF
--- a/src/common/assistant.cpp
+++ b/src/common/assistant.cpp
@@ -53,7 +53,7 @@ void systemPause() {
 #ifdef _WIN32
 	system("pause");
 #else
-	system("read");
+	int _unused = system("read");
 #endif // _WIN32
 }
 

--- a/src/common/conf.cpp
+++ b/src/common/conf.cpp
@@ -9,13 +9,12 @@
 #include <iostream>
 #include <sstream>
 
-#ifndef Pandas_Support_Read_UTF8BOM_Configure
+#ifndef Pandas_Support_UTF8BOM_Files
 int conf_read_file(config_t *config, const char *config_filename)
 #else
-// 若启用了 Pandas_Support_Read_UTF8BOM_Configure 则重命名该函数
-// 以便重载一个签名完全一致的函数接管其处理逻辑
+// 重命名该函数以便重载一个签名完全一致的函数接管其处理逻辑
 int conf_read_file_internal(config_t* config, const char* config_filename)
-#endif // Pandas_Support_Read_UTF8BOM_Configure
+#endif // Pandas_Support_UTF8BOM_Files
 {
 	config_init(config);
 	if (!config_read_file(config, config_filename)) {
@@ -27,7 +26,7 @@ int conf_read_file_internal(config_t* config, const char* config_filename)
 	return 0;
 }
 
-#ifdef Pandas_Support_Read_UTF8BOM_Configure
+#ifdef Pandas_Support_UTF8BOM_Files
 //************************************
 // Method:      conf_read_file
 // Description: 能够对 UTF8-BOM 自动转码的 libconfig 读取函数
@@ -71,7 +70,7 @@ int conf_read_file(config_t* config, const char* config_filename)
 	}
 	return 0;
 }
-#endif // Pandas_Support_Read_UTF8BOM_Configure
+#endif // Pandas_Support_UTF8BOM_Files
 
 //
 // Functions to copy settings from libconfig/contrib

--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -402,7 +402,7 @@ int32 YamlDatabase::getLineNumber(const ryml::NodeRef& node) {
 		// 读取到的行号应该 + 1 才是正确的行号
 		return parser.source().has_str() ? (int32)parser.location(node).line + 1 : 0;
 	}
-	catch (std::runtime_error const& err) {
+	catch (std::runtime_error) {
 #ifdef DEBUG
 		std::cout << node;
 #endif // DEBUG
@@ -418,7 +418,7 @@ int32 YamlDatabase::getColumnNumber(const ryml::NodeRef& node) {
 	try {
 		return parser.source().has_str() ? (int32)parser.location(node).col : 0;
 	}
-	catch (std::runtime_error const& err) {
+	catch (std::runtime_error) {
 #ifdef DEBUG
 		std::cout << node;
 #endif // DEBUG

--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -147,7 +147,7 @@ bool YamlDatabase::load(const std::string& path) {
 	// 潜在的编码转换需要, 将缓冲区的大小扩大三倍
 	char* buf = (char *)aMalloc(size*3+1);
 	rewind(f);
-	size_t real_size = fread(buf, sizeof(char), size*3, f);
+	size_t real_size = _fread(buf, sizeof(char), size*3, f, (this->type == "CONSOLE_TRANSLATE_DB" ? 0x2 : 0));
 #endif // Pandas_Support_Read_UTF8BOM_Configure
 	// Zero terminate
 	buf[real_size] = '\0';

--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -139,7 +139,7 @@ bool YamlDatabase::load(const std::string& path) {
 	}
 	fseek(f, 0, SEEK_END);
 	size_t size = ftell(f);
-#ifndef Pandas_Support_Read_UTF8BOM_Configure
+#ifndef Pandas_Support_UTF8BOM_Files
 	char* buf = (char *)aMalloc(size+1);
 	rewind(f);
 	size_t real_size = fread(buf, sizeof(char), size, f);
@@ -148,7 +148,7 @@ bool YamlDatabase::load(const std::string& path) {
 	char* buf = (char *)aMalloc(size*3+1);
 	rewind(f);
 	size_t real_size = _fread(buf, sizeof(char), size*3, f, (this->type == "CONSOLE_TRANSLATE_DB" ? 0x2 : 0));
-#endif // Pandas_Support_Read_UTF8BOM_Configure
+#endif // Pandas_Support_UTF8BOM_Files
 	// Zero terminate
 	buf[real_size] = '\0';
 	fclose(f);

--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -174,6 +174,7 @@ bool YamlDatabase::load(const std::string& path) {
 		ShowWarning("Press any key to continue reading other files, but it usually means a lot of errors.\n");
 		ShowError("%s\n", err.what());
 		systemPause();
+		aFree(buf);
 		return false;
 	}
 #endif // Pandas_UserExperience_Yaml_Error

--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -144,10 +144,15 @@ bool YamlDatabase::load(const std::string& path) {
 	rewind(f);
 	size_t real_size = fread(buf, sizeof(char), size, f);
 #else
-	// 潜在的编码转换需要, 将缓冲区的大小扩大三倍
-	char* buf = (char *)aMalloc(size*3+1);
+	// 潜在的编码转换需要, 将字节数与 wchar_t 的大小相乘
+	size = size * sizeof(wchar_t) + 1;
+	char* buf = (char *)aMalloc(size);
 	rewind(f);
-	size_t real_size = _fread(buf, sizeof(char), size*3, f, (this->type == "CONSOLE_TRANSLATE_DB" ? 0x2 : 0));
+	// 加载终端翻译数据库的时候标记位需要传递为 0x2
+	// 表示在将其 UTF8 内容转换成 BIG5 编码的时候需要在低字节位为 0x5C 的字符后追加反斜杠
+	// 这样处理后在终端显示出对应的汉字，比如：連線成功 最末尾的【功】才能正常显示
+	int flag = (this->type == "CONSOLE_TRANSLATE_DB" ? 0x2 : 0);
+	size_t real_size = _fread(buf, sizeof(char), size, f, flag);
 #endif // Pandas_Support_UTF8BOM_Files
 	// Zero terminate
 	buf[real_size] = '\0';
@@ -392,13 +397,33 @@ int32 YamlDatabase::getLineNumber(const ryml::NodeRef& node) {
 #ifndef Pandas_UserExperience_Yaml_Error
 	return parser.source().has_str() ? (int32)parser.location(node).line : 0;
 #else
-	// 读取到的行号应该 + 1 才是正确的行号
-	return parser.source().has_str() ? (int32)parser.location(node).line + 1 : 0;
+	try {
+		// 读取到的行号应该 + 1 才是正确的行号
+		return parser.source().has_str() ? (int32)parser.location(node).line + 1 : 0;
+	}
+	catch (std::runtime_error const& err) {
+#ifdef DEBUG
+		std::cout << node;
+#endif // DEBUG
+		return 0;
+	}
 #endif // Pandas_UserExperience_Yaml_Error
 }
 
 int32 YamlDatabase::getColumnNumber(const ryml::NodeRef& node) {
+#ifndef Pandas_UserExperience_Yaml_Error
 	return parser.source().has_str() ? (int32)parser.location(node).col : 0;
+#else
+	try {
+		return parser.source().has_str() ? (int32)parser.location(node).col : 0;
+	}
+	catch (std::runtime_error const& err) {
+#ifdef DEBUG
+		std::cout << node;
+#endif // DEBUG
+		return 0;
+	}
+#endif // Pandas_UserExperience_Yaml_Error
 }
 
 void YamlDatabase::invalidWarning( const ryml::NodeRef& node, const char* fmt, ... ){

--- a/src/common/utf8.hpp
+++ b/src/common/utf8.hpp
@@ -74,8 +74,10 @@ void clearModeMapping(FILE* _fp);
 enum e_file_charsetmode fmode(FILE* _Stream);
 enum e_file_charsetmode fmode(std::ifstream& ifs);
 FILE* fopen(const char* _FileName, const char* _Mode);
-char* fgets(char* _Buffer, int _MaxCount, FILE* _Stream);
-size_t fread(void* _Buffer, size_t _ElementSize, size_t _ElementCount, FILE* _Stream);
+char* fgets(char* _Buffer, int _MaxCount, FILE* _Stream, int flag = 0);
+char* _fgets(char* _Buffer, int _MaxCount, FILE* _Stream, int flag = 0);
+size_t fread(void* _Buffer, size_t _ElementSize, size_t _ElementCount, FILE* _Stream, int flag = 0);
+size_t _fread(void* _Buffer, size_t _ElementSize, size_t _ElementCount, FILE* _Stream, int flag = 0);
 int fclose(FILE* _fp);
 
 } // namespace PandasUtf8

--- a/src/common/utf8_defines.hpp
+++ b/src/common/utf8_defines.hpp
@@ -12,4 +12,7 @@
 	#define fgets(BUFFER, MAXCOUNT, STREAM) PandasUtf8::fgets(BUFFER, MAXCOUNT, STREAM)
 	#define fread(BUFFER, ELESIZE, ELECOUNT, STREAM) PandasUtf8::fread(BUFFER, ELESIZE, ELECOUNT, STREAM)
 	#define fclose(FPOINTER) PandasUtf8::fclose(FPOINTER)
+
+	#define _fgets(BUFFER, MAXCOUNT, STREAM, FLAG) PandasUtf8::_fgets(BUFFER, MAXCOUNT, STREAM, FLAG)
+	#define _fread(BUFFER, ELESIZE, ELECOUNT, STREAM, FLAG) PandasUtf8::_fread(BUFFER, ELESIZE, ELECOUNT, STREAM, FLAG)
 #endif // Pandas_Support_Read_UTF8BOM_Configure

--- a/src/common/utf8_defines.hpp
+++ b/src/common/utf8_defines.hpp
@@ -4,10 +4,9 @@
 #pragma once
 
 #include "../config/pandas.hpp"
+#include "../common/utf8.hpp"
 
-#ifdef Pandas_Support_Read_UTF8BOM_Configure
-	#include "../common/utf8.hpp"
-
+#ifdef Pandas_Support_UTF8BOM_Files
 	#define fopen(FNAME, MODE) PandasUtf8::fopen(FNAME, MODE)
 	#define fgets(BUFFER, MAXCOUNT, STREAM) PandasUtf8::fgets(BUFFER, MAXCOUNT, STREAM)
 	#define fread(BUFFER, ELESIZE, ELECOUNT, STREAM) PandasUtf8::fread(BUFFER, ELESIZE, ELECOUNT, STREAM)
@@ -15,4 +14,4 @@
 
 	#define _fgets(BUFFER, MAXCOUNT, STREAM, FLAG) PandasUtf8::_fgets(BUFFER, MAXCOUNT, STREAM, FLAG)
 	#define _fread(BUFFER, ELESIZE, ELECOUNT, STREAM, FLAG) PandasUtf8::_fread(BUFFER, ELESIZE, ELECOUNT, STREAM, FLAG)
-#endif // Pandas_Support_Read_UTF8BOM_Configure
+#endif // Pandas_Support_UTF8BOM_Files

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -245,9 +245,6 @@
 	// 是否拓展 Yaml 的 Database 操作类使之能抑制错误信息 [Sola丶小克]
 	#define Pandas_Database_Yaml_BeQuiet
 
-	// 是否拓展 Yaml 的 Database 操作类使之能读取 UTF8-BOM 编码的文件 [Sola丶小克]
-	#define Pandas_Database_Yaml_Support_UTF8BOM
-
 	// 是否支持用于读取 SQL 连接编码的 Sql_GetEncoding 函数 [Sola丶小克]
 	#define Pandas_Database_SQL_GetEncoding
 #endif // Pandas_DatabaseIncrease
@@ -509,8 +506,8 @@
 		#define Pandas_Support_Specify_PacketKeys
 	#endif // PACKET_OBFUSCATION
 
-	// 是否支持读取 UTF8-BOM 编码的 libconfig 配置文件 [Sola丶小克]
-	#define Pandas_Support_Read_UTF8BOM_Configure
+	// 是否支持读取 UTF8-BOM 编码的配置或者数据文件 [Sola丶小克]
+	#define Pandas_Support_UTF8BOM_Files
 
 	// 在使用 _M/_F 注册的时候, 能够限制使用中文等字符作为游戏账号 [Sola丶小克]
 	// 这里的 PCRE_SUPPORT 在"项目属性 -> C/C++ -> 预处理器"中定义
@@ -685,7 +682,10 @@
 	#endif // Pandas_Struct_Map_Session_Data_Skip_LoadEndAck_NPC_Event_Dequeue
 
 	// 是否支持根据系统语言读取对应的消息数据库文件 [Sola丶小克]
-	#define Pandas_Adaptive_Importing_Message_Database
+	// 此选项依赖 Pandas_Support_UTF8BOM_Files 的拓展
+	#ifdef Pandas_Support_UTF8BOM_Files
+		#define Pandas_Adaptive_Importing_Message_Database
+	#endif // Pandas_Support_UTF8BOM_Files
 
 	// 是否支持处理 Windows 10 编码选项带来的中文乱码问题 [Sola丶小克]
 	// Beta: Use Unicode UTF-8 for worldwide language support

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -6125,10 +6125,11 @@ int npc_parsesrcfile(const char* filepath)
 	fseek(fp, 0, SEEK_SET);
 	len = fread(buffer, 1, len, fp);
 #else
-	// 潜在的编码转换需要, 将缓冲区的大小扩大三倍
-	buffer = (char*)aMalloc(len*3+1);
+	// 潜在的编码转换需要, 将字节数与 wchar_t 的大小相乘
+	len = len * sizeof(wchar_t) + 1;
+	buffer = (char*)aMalloc(len);
 	fseek(fp, 0, SEEK_SET);
-	len = fread(buffer, 1, len*3, fp);
+	len = fread(buffer, 1, len, fp);
 #endif // Pandas_Support_UTF8BOM_Files
 	buffer[len] = '\0';
 	if( ferror(fp) )

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -6120,7 +6120,7 @@ int npc_parsesrcfile(const char* filepath)
 	}
 	fseek(fp, 0, SEEK_END);
 	len = ftell(fp);
-#ifndef Pandas_Support_Read_UTF8BOM_Configure
+#ifndef Pandas_Support_UTF8BOM_Files
 	buffer = (char*)aMalloc(len+1);
 	fseek(fp, 0, SEEK_SET);
 	len = fread(buffer, 1, len, fp);
@@ -6129,7 +6129,7 @@ int npc_parsesrcfile(const char* filepath)
 	buffer = (char*)aMalloc(len*3+1);
 	fseek(fp, 0, SEEK_SET);
 	len = fread(buffer, 1, len*3, fp);
-#endif // Pandas_Support_Read_UTF8BOM_Configure
+#endif // Pandas_Support_UTF8BOM_Files
 	buffer[len] = '\0';
 	if( ferror(fp) )
 	{


### PR DESCRIPTION
## 修正之前

npc 聊天窗口中的对话，在出现 0x5C 冲码的字符后面会多一个反斜杠

## 修正之后

情况如下图

![image](https://user-images.githubusercontent.com/4458917/181919883-7df13a61-a389-4886-bab9-c823045dae73.png)

