### PR TITLE
当 YAML 数据文件中不存在 Body 节点时也依然输出结尾信息

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -232,6 +232,18 @@ void YamlDatabase::parse( const ryml::Tree& tree ){
 		ShowStatus( "Done reading '" CL_WHITE "%" PRIu64 CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "' (took %" PRIu64 " milliseconds)" CL_CLL "\n", count, fileName, performance_get_milliseconds("yamldatabase_load"));
 #endif // Pandas_Speedup_Print_TimeConsuming_Of_KeySteps
 	}
+#ifdef Pandas_UserExperience_Output_Ending_Even_Body_Node_Is_Not_Exists
+	else {
+		// 当数据文件中不存在 Body 节点时也依然输出结尾信息
+		const char* fileName = this->currentFile.c_str();
+#ifndef Pandas_Speedup_Print_TimeConsuming_Of_KeySteps
+		ShowStatus("Done reading '" CL_WHITE "%" PRIu64 CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\n", count, fileName);
+#else
+		performance_stop("yamldatabase_load");
+		ShowStatus("Done reading '" CL_WHITE "%" PRIu64 CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "' (took %" PRIu64 " milliseconds)" CL_CLL "\n", count, fileName, performance_get_milliseconds("yamldatabase_load"));
+#endif // Pandas_Speedup_Print_TimeConsuming_Of_KeySteps
+	}
+#endif // Pandas_UserExperience_Output_Ending_Even_Body_Node_Is_Not_Exists
 }
 
 void YamlDatabase::parseImports( const ryml::Tree& rootNode ){

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1234,6 +1234,9 @@
 
 	// 优化加载与解析 YAML 文件时出现的一些报错体验 [Sola丶小克]
 	#define Pandas_UserExperience_Yaml_Error
+
+	// 当 YAML 数据文件中不存在 Body 节点时也依然输出结尾信息 [Sola丶小克]
+	#define Pandas_UserExperience_Output_Ending_Even_Body_Node_Is_Not_Exists
 #endif // Pandas_UserExperience
 
 // ============================================================================


### PR DESCRIPTION
此提交主要修正了一个体验问题

- 假定 conf/import/atcommand.yml 保持默认状态（没有 Body 节点）
- 然后游戏内使用 `@reloadatcommand` 来重新加载对应的数据文件
- 你会看到游戏内提示刷新完毕，但地图服务器的终端窗口中依然显示：正在加载 `conf/import/atcommand.yml`...
- 这是因为 `conf/import/atcommand.yml` 中没有 Body 节点而导致程序绕过了结束信息的输出
- 看起来好像卡主了，实际上没卡住