### PR TITLE
修正拥有 BSF_REM_ON_LOGOUT 标记位的 bonus_script 极少数情况下会在重登后生效的问题 [感谢 "香草" 反馈]

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -986,6 +986,18 @@
 	// 修正 inter_server.yml 中的 Max 超大时没有妥善处理的问题 [Sola丶小克]
 	// 启用后 Max 字段的值最多不能超过 MAX_STORAGE 的值
 	#define Pandas_Fix_INTER_SERVER_DB_Field_Verify
+
+	// 修正特殊情况下 bonus_script 拥有 BSF_REM_ON_LOGOUT 标记位,
+	// 也会在重新进入游戏时生效的问题 [Sola丶小克]
+	// 
+	// 正常情况下角色若正常退出游戏, 标记位包含 BSF_REM_ON_LOGOUT 的 bonus_script 不会被记录,
+	// 那怕由于操作仓库而导致角色数据被提前保存, 也会在角色退出的时候被清除.
+	//
+	// 但如果在包含 BSF_REM_ON_LOGOUT 的 bonus_script 记录在数据库时强制关闭地图服务器,
+	// 那么这条 bonus_script 将会保存到下次服务器启动, 并且玩家进入游戏时还有效.
+	//
+	// 解决方案: 进入游戏加载 bonus_script 的时候抛弃拥有 BSF_REM_ON_LOGOUT 标记位的数据
+	#define Pandas_Fix_Bonus_Script_Effective_Timing_Exception
 #endif // Pandas_Bugfix
 
 // ============================================================================

--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -1795,6 +1795,18 @@ int chrif_bsdata_received(int fd) {
 			if (bs->script_str[0] == '\0' || !bs->tick)
 				continue;
 
+#ifdef Pandas_Fix_Bonus_Script_Effective_Timing_Exception
+			if ((bs->flag & BSF_REM_ON_LOGOUT) == BSF_REM_ON_LOGOUT) {
+				// 若 bonus_script 被打上了 BSF_REM_ON_LOGOUT 标记位, 那么它不应该再被加载.
+				//
+				// 目前看应该只有在玩家进入游戏的时候,
+				// 地图服务器在 intif_parse_Registers 收到角色服务器发来的全部变量数据之后,
+				// 才会触发 pc_reg_received -> chrif_bsdata_request -> 来请求 bonus_script 数据,
+				// 最终落到本函数 chrif_bsdata_received 进行处理.
+				continue;
+			}
+#endif // Pandas_Fix_Bonus_Script_Effective_Timing_Exception
+
 #ifndef Pandas_BonusScript_Unique_ID
 			if (!(entry = pc_bonus_script_add(sd, bs->script_str, bs->tick, (enum efst_type)bs->icon, bs->flag, bs->type)))
 				continue;


### PR DESCRIPTION
- 此问题的重现方法已经在代码注释中写出
- 影响风险比较低，只有地图服务器异常退出的时候才有可能触发此问题

特别感谢 @VanillaIRV 反馈此问题