### PR TITLE
修正 breakpad 在 Ubuntu 22.04 LTS 无法被默认的 gcc-11 顺利编译的问题

### DIFF
--- a/3rdparty/breakpad/src/client/linux/handler/exception_handler.cc
+++ b/3rdparty/breakpad/src/client/linux/handler/exception_handler.cc
@@ -138,7 +138,7 @@ void InstallAlternateStackLocked() {
   // SIGSTKSZ may be too small to prevent the signal handlers from overrunning
   // the alternative stack. Ensure that the size of the alternative stack is
   // large enough.
-  static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
+  static const unsigned kSigStackSize = std::max(16384u, (unsigned)SIGSTKSZ);
 
   // Only set an alternative stack if there isn't already one, or if the current
   // one is too small.


### PR DESCRIPTION
感谢 @cloudman123 在 #624 中指出此问题