### PR TITLE
修正 sprintf 脚本指令无法格式化 int64 数值的问题

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -998,6 +998,10 @@
 	//
 	// 解决方案: 进入游戏加载 bonus_script 的时候抛弃拥有 BSF_REM_ON_LOGOUT 标记位的数据
 	#define Pandas_Fix_Bonus_Script_Effective_Timing_Exception
+
+	// 修正 sprintf 脚本指令无法格式化 int64 数值的问题 [Sola丶小克]
+	// 注意: 即使启用此选项, 当你需要格式化 int64 的数值时依然需要使用 %lld 而不是 %d
+	#define Pandas_Fix_Sprintf_ScriptCommand_Unsupport_Int64
 #endif // Pandas_Bugfix
 
 // ============================================================================

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -18065,14 +18065,22 @@ BUILDIN_FUNC(sprintf)
 		if(data_isstring(data))  // String
 			StringBuf_Printf(&final_buf, buf2, script_getstr(st, arg+3));
 		else if(data_isint(data))  // Number
+#ifndef Pandas_Fix_Sprintf_ScriptCommand_Unsupport_Int64
 			StringBuf_Printf(&final_buf, buf2, script_getnum(st, arg+3));
+#else
+			StringBuf_Printf(&final_buf, buf2, script_getnum64(st, arg+3));
+#endif // Pandas_Fix_Sprintf_ScriptCommand_Unsupport_Int64
 		else if(data_isreference(data)) {  // Variable
 			char* name = reference_getname(data);
 
 			if(name[strlen(name)-1]=='$')  // var Str
 				StringBuf_Printf(&final_buf, buf2, script_getstr(st, arg+3));
 			else  // var Int
+#ifndef Pandas_Fix_Sprintf_ScriptCommand_Unsupport_Int64
 				StringBuf_Printf(&final_buf, buf2, script_getnum(st, arg+3));
+#else
+				StringBuf_Printf(&final_buf, buf2, script_getnum64(st, arg+3));
+#endif // Pandas_Fix_Sprintf_ScriptCommand_Unsupport_Int64
 		} else {  // Unsupported type
 			ShowError("buildin_sprintf: Unknown argument type!\n");
 			if(buf) aFree(buf);


### PR DESCRIPTION
- 使用 sprintf 通过 %d 或 %lld 来格式化 getinventoryinfo 获取到的 uid，会发现输出不正常
- 修正后，可以使用 %lld 来格式化 int64 的数值