### PR TITLE
当 st 被释放的时候移除玩家 st 备份清单中的副本

### DIFF
--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -505,7 +505,7 @@ struct map_session_data {
 	int npc_amount;
 	struct script_state *st;
 #ifdef Pandas_ScriptEngine_MutliStackBackup
-	std::stack<mutli_state, std::vector<mutli_state>> mbk_st;
+	std::vector<mutli_state> previous_st;
 #endif // Pandas_ScriptEngine_MutliStackBackup
 	char npc_str[CHATBOX_SIZE]; // for passing npc input box text to script engine
 	int npc_timer_id; //For player attached npc timers. [Skotlex]

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3467,12 +3467,12 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 			}
 
 #ifdef Pandas_ScriptEngine_MutliStackBackup
-			while (!sd->mbk_st.empty()) {
-				struct mutli_state val = sd->mbk_st.top();
+			while (!sd->previous_st.empty()) {
+				struct mutli_state val = sd->previous_st.back();
 				if (val.bk_st != nullptr) {
-					script_free_state(sd->mbk_st.top().bk_st);
+					script_free_state(val.bk_st);
 				}
-				sd->mbk_st.pop();
+				sd->previous_st.pop_back();
 			}
 #endif // Pandas_ScriptEngine_MutliStackBackup
 


### PR DESCRIPTION
### 问题说明

多层脚本堆栈备份机制在完成 script_state 备份后，如果备份中的 script_state 被 free 掉，程序没有清空玩家身上备份的 script_state 队列，最终会导致在某个时刻恢复到一个已经不存在的 script_state 上，导致程序异常

### 主要改动

- 在 script_free_state 中进行处理，从备份列表中移除即将被释放的 script_state