### PR TITLE
修正在 Linux 平台下编译项目时存在的一些问题

### DIFF
--- a/3rdparty/breakpad/src/common/linux/http_upload.cc
+++ b/3rdparty/breakpad/src/common/linux/http_upload.cc
@@ -73,8 +73,8 @@ bool HTTPUpload::SendRequest(const string &url,
   // current binary, no need to search for a dynamic version.
   void* curl_lib = dlopen(NULL, RTLD_NOW);
   if (!CheckCurlLib(curl_lib)) {
-    fprintf(stderr,
-            "Failed to open curl lib from binary, use libcurl.so instead\n");
+    //fprintf(stderr,
+    //        "Failed to open curl lib from binary, use libcurl.so instead\n");
     dlerror();  // Clear dlerror before attempting to open libraries.
     dlclose(curl_lib);
     curl_lib = NULL;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,21 @@ if(CCACHE_EXECUTABLE)
 endif()
 
 #
+# 对编译器的版本进行必要的检查
+#
+if( NOT WIN32 )
+	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+			message(FATAL_ERROR "GCC version must be at least 8.0 !")
+		endif()
+	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
+			message(FATAL_ERROR "Clang version must be at least 6.0 !")
+		endif()
+	endif()
+endif()
+
+#
 # Global stuff
 #
 set( GLOBAL_LIBRARIES ${LINK_LIBRARIES}  CACHE INTERNAL "" )# list (comma separated values)


### PR DESCRIPTION
修正 #627 中出现的缺陷：
- 在 Linux 平台下进行编译时, 对编译器的版本进行必要的检查
  - gcc 要求至少 8.x 版本；clang 要求至少 6.x 版本
- 移除程序崩溃时 breakpad 给出的警告信息（眼不见心不烦，毕竟可以继续用动态库进行工作）

感谢 @lm884612 和 @Ruisi-Lu 做出的贡献