### PR TITLE
使用docker來降低跨平台門檻

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,77 @@
+version: "3.9"
+services:
+    mysql:
+        image: mysql
+        volumes:
+            - mysql:/var/lib/mysql
+            - ./sql-files/main.sql:/sql-files/main.sql
+            - ./sql-files/logs.sql:/sql-files/logs.sql
+            - ./sql-files/docker_init.sh:/docker-entrypoint-initdb.d/docker_init.sh
+        ports:
+            - "3306:3306"
+        environment:
+            MYSQL_ROOT_PASSWORD: "123456"
+    login:
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: login
+        ports:
+            - "6900:6900"
+        links:
+            - "mysql:mysql"
+        volumes:
+            - ./conf:/app/conf
+            - ./npc:/app/npc
+            - ./db:/app/db
+        depends_on:
+            - "mysql"
+    char:
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: char
+        ports:
+            - "6121:6121"
+        links:
+            - "mysql:mysql"
+            - "login:login"
+        volumes:
+            - ./conf:/app/conf
+            - ./npc:/app/npc
+            - ./db:/app/db
+        depends_on:
+            - "mysql"
+    map:
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: map
+        ports:
+            - "5121:5121"
+        links:
+            - "mysql:mysql"
+            - "char:char"
+        volumes:
+            - ./conf:/app/conf
+            - ./npc:/app/npc
+            - ./db:/app/db
+        depends_on:
+            - "mysql"
+    web:
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: web
+        ports:
+            - "3000:3000"
+        links:
+            - "mysql:mysql"
+        volumes:
+            - ./conf:/app/conf
+            - ./npc:/app/npc
+            - ./db:/app/db
+        depends_on:
+            - "mysql"
+volumes:
+    mysql:

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,51 @@
+FROM ubuntu:20.04 AS build
+WORKDIR /build
+RUN apt update -y
+RUN apt install make libmysqlclient-dev musl python3-dev build-essential wget -y
+RUN  wget https://github.com/Kitware/CMake/releases/download/v3.16.0-rc1/cmake-3.16.0-rc1.tar.gz \
+  && tar -xzvf cmake-3.16.0-rc1.tar.gz \
+  && cd cmake-3.16.0-rc1 \
+  && ./bootstrap && make -j4 && make install
+COPY 3rdparty ./3rdparty
+WORKDIR /build/3rdparty/boost
+RUN sh ./bootstrap.sh && ./b2
+WORKDIR /build
+COPY src ./src
+COPY CMakeLists.txt ./
+COPY LICENSE ./
+WORKDIR /build/cbuild
+RUN cmake -G "Unix Makefiles" ..
+CMD sh
+RUN make
+
+FROM ubuntu:20.04 AS login
+WORKDIR /app
+COPY --from=build /build/login-server ./
+RUN apt update -y
+RUN apt install libmysqlclient-dev -y
+RUN apt-get clean autoclean && apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/
+ENTRYPOINT ["./login-server"]
+
+FROM ubuntu:20.04 AS char
+WORKDIR /app
+COPY --from=build /build/char-server ./
+RUN apt update -y
+RUN apt install libmysqlclient-dev -y
+RUN apt-get clean autoclean && apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/
+ENTRYPOINT ["./char-server"]
+
+FROM ubuntu:20.04 AS map
+WORKDIR /app
+COPY --from=build /build/map-server ./
+RUN apt update -y
+RUN apt install libmysqlclient-dev -y
+RUN apt-get clean autoclean && apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/
+ENTRYPOINT ["./map-server"]
+
+FROM ubuntu:20.04 AS web
+WORKDIR /app
+COPY --from=build /build/web-server ./
+RUN apt update -y
+RUN apt install libmysqlclient-dev -y
+RUN apt-get clean autoclean && apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/
+ENTRYPOINT ["./web-server"]

--- a/sql-files/docker_init.sh
+++ b/sql-files/docker_init.sh
@@ -1,0 +1,7 @@
+mysql -uroot -p$MYSQL_ROOT_PASSWORD -e"CREATE DATABASE ragnarok;"
+# mysql -uroot -p$MYSQL_ROOT_PASSWORD -e"CREATE DATABASE logs;"
+mysql -uroot -p$MYSQL_ROOT_PASSWORD ragnarok < /sql-files/main.sql
+mysql -uroot -p$MYSQL_ROOT_PASSWORD ragnarok < /sql-files/logs.sql
+mysql -uroot -p$MYSQL_ROOT_PASSWORD -e"CREATE USER 'ragnarok'@'%' IDENTIFIED BY 'ragnarok';"
+mysql -uroot -p$MYSQL_ROOT_PASSWORD -e"grant all privileges on *.* to 'ragnarok'@'%' with grant option;"
+mysql -uroot -p$MYSQL_ROOT_PASSWORD -e"flush privileges;"


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
藉由docker進行編譯，使其能在任何支援容器的平台上使用
並添加docker-compose以方便一鍵部署伺服器
## 優點
- 可攜性，降低伺服器遷移成本
- 跨平台，使其能在任何支援容器的平台使用
- 不需要理會任何環境配置
- 快速部署，只需要一行指令即可拉起伺服器，方便於測試及生產環境部署
- (?)對於不熟悉linux的用戶也能在linux上輕鬆部署，減少windows授權費用及硬體需求
- 支援k8s進行部分服務水平部署

## 注意
用於生產環境需要自行注意任何安全性設定

## 如何使用 Docker-compose一鍵部署
1. 配置conf 修改以下參數
``` 
// char_athena.conf
login_ip: login
char_ip: char
```
```
// map_athena.conf
char_ip: char
map_ip: map
```
```
//inter_athena.conf
login_server_ip: mysql
ipban_db_ip: mysql
char_server_ip: mysql
map_server_ip: mysql
web_server_ip: mysql
log_db_ip: mysql
```
2. 安裝Docker，詳細參閱: https://docs.docker.com/get-docker/
3. 運行Docker
4. 變更終端指令目錄至Pandas `cd Pandas`
5. 在終端指令中`docker-compose up`
6. 等待容器編譯及建構，完成後將自動拉起服務