### PR TITLE
过滤器事件必须存在才允许执行, 避免程序汇报 nullpo 空指针 (感谢 "山有" 反馈)

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -7576,7 +7576,7 @@ bool npc_script_filter(struct map_session_data* sd, const char* eventname) {
 	nullpo_retr(false, sd);
 	enum npce_event type = npc_get_script_event_type(eventname);
 	struct event_data* ev = (struct event_data*)strdb_get(ev_db, eventname);
-	if (!npc_event_rightnow(sd, ev, eventname))
+	if (ev && !npc_event_rightnow(sd, ev, eventname))
 		return false;
 	return getProcessHalt(sd, type);
 }


### PR DESCRIPTION
## 问题描述

当进入一个 npc 开启的聊天室时，若该 npc 没有定义 OnPCInChatroomFilter 标签，会导致地图服务器显示：

```
--- nullpo info --------------------------------------------
src\map\npc.cpp:6621: in func `npc_event_rightnow'
```

## 问题原因

程序判断不严格，调整程序逻辑在执行指定 NPC 下的某个具体过滤器事件时，若指定的事件不存在则不执行后续逻辑

## 重现方法

- 加载以下 npc，点击一下创建出聊天室
- 双击进入聊天室，观察地图服务器是否提示 nullpo 信息

```
prontera,150,150,3	script	tester#al	123,{
	donpcevent "tester#al::On111";
end;
On111:
	waitingroom "123",10;
end;
}
```