### PR TITLE
修正 setunitdata 对魔物的部分属性调整会继承到魔物下一次重生的问题 (感谢 "差记性的小北" 反馈)

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1001,6 +1001,17 @@
 	// 修正 sprintf 脚本指令无法格式化 int64 数值的问题 [Sola丶小克]
 	// 注意: 即使启用此选项, 当你需要格式化 int64 的数值时依然需要使用 %lld 而不是 %d
 	#define Pandas_Fix_Sprintf_ScriptCommand_Unsupport_Int64
+
+	// 修正 setunitdata 对魔物的部分属性调整会继承到魔物下一次重生的问题 [Sola丶小克]
+	// 
+	// 当一个魔物是由自然刷怪点刷新出来的话, 杀死它并不会导致 md 的数据被清空,
+	// 而是会被设置一个重生时间 (spawn_timer), 下次重生的时候还会携带上次 setunitdata 时候的信息.
+	// 因此, 若魔物的某个属性可以在 setunitdata 中被修改,
+	// 且保存其值的变量不在 md->base_status 结构体中, 那么需要手动重置一下.
+	//
+	// 特别感谢 "差记性的小北" 指出此问题
+	#define Pandas_Fix_SetUnitData_Forget_Reset_After_Monster_Dead
+	
 #endif // Pandas_Bugfix
 
 // ============================================================================

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1009,6 +1009,11 @@
 	// 因此, 若魔物的某个属性可以在 setunitdata 中被修改,
 	// 且保存其值的变量不在 md->base_status 结构体中, 那么需要手动重置一下.
 	//
+	// 备注: md->base_status 结构体中的属性在魔物重生时在 status_calc_mob_ 中被重置,
+	// 因此我们不需要手动重置 md->base_status 结构体中的这些属性.
+	//
+	// 已知 UMOB_MASTERAID 在 mob_spawn 中故意不重置
+	//
 	// 特别感谢 "差记性的小北" 指出此问题
 	#define Pandas_Fix_SetUnitData_Forget_Reset_After_Monster_Dead
 	

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1237,7 +1237,9 @@ int mob_spawn (struct mob_data *md)
 #endif // Pandas_Struct_Unit_CommonData_Aura
 
 #ifdef Pandas_ScriptParams_DamageTaken_Extend
-	md->damagetaken = md->db->damagetaken;
+	if (md->db) {
+		md->damagetaken = md->db->damagetaken;
+	}
 #endif // Pandas_ScriptParams_DamageTaken_Extend
 
 #ifdef Pandas_Struct_Mob_Data_SpecialExperience
@@ -1252,17 +1254,27 @@ int mob_spawn (struct mob_data *md)
 #endif // Pandas_Struct_Mob_Data_Special_SetUnitData
 
 #ifdef Pandas_Fix_SetUnitData_Forget_Reset_After_Monster_Dead
+	status_set_viewdata(&md->bl, md->mob_id);
+	md->ud.immune_attack = false;
+	md->ud.canmove_tick = gettick();
+	md->ud.group_id = 0;
+	md->ud.state.ignore_cell_stack_limit = 0;
+
 	if (md->db) {
-		if (battle_config.override_mob_names == 1)
-			memcpy(md->name, md->db->name.c_str(), sizeof(md->name));
-		else if (battle_config.override_mob_names == 2)
-			memcpy(md->name, md->db->jname.c_str(), sizeof(md->name));
-		else {
-			if (md->spawn)
-				memcpy(md->name, md->spawn->name, sizeof(md->name));
-			else
-				memcpy(md->name, md->db->jname.c_str(), sizeof(md->name));
-		}
+		md->level = md->db->lv;
+	}
+
+	if (md->spawn) {
+		safestrncpy(md->name, md->spawn->name, sizeof(md->name));
+
+		if (md->spawn->level > 0)
+			md->level = md->spawn->level;
+
+		if (md->spawn->state.ai)
+			md->special_state.ai = md->spawn->state.ai;
+
+		if (md->spawn->state.size)
+			md->special_state.size = md->spawn->state.size;
 	}
 #endif // Pandas_Fix_SetUnitData_Forget_Reset_After_Monster_Dead
 

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1228,6 +1228,42 @@ int mob_spawn (struct mob_data *md)
 	batrec_reset(&md->bl);
 #endif // Pandas_BattleRecord
 
+// =======================================================================
+// 非 md->base_status 中的数据但可以被 setunitdata 修改的属性重置 - 以下开始
+// =======================================================================
+
+#ifdef Pandas_Struct_Unit_CommonData_Aura
+	memset(&md->ucd.aura, 0, sizeof(md->ucd.aura));
+#endif // Pandas_Struct_Unit_CommonData_Aura
+
+#ifdef Pandas_ScriptParams_DamageTaken_Extend
+	md->damagetaken = md->db->damagetaken;
+#endif // Pandas_ScriptParams_DamageTaken_Extend
+
+#ifdef Pandas_Struct_Mob_Data_SpecialExperience
+	md->pandas.base_exp = -1;
+	md->pandas.job_exp = -1;
+#endif // Pandas_Struct_Mob_Data_SpecialExperience
+
+#ifdef Pandas_Struct_Mob_Data_Special_SetUnitData
+	if (md->pandas.special_setunitdata) {
+		md->pandas.special_setunitdata->clear();
+	}
+#endif // Pandas_Struct_Mob_Data_Special_SetUnitData
+
+#ifdef Pandas_Fix_SetUnitData_Forget_Reset_After_Monster_Dead
+	if (md->db) {
+		if (battle_config.override_mob_names == 1)
+			memcpy(md->name, md->db->name.c_str(), NAME_LENGTH);
+		else
+			memcpy(md->name, md->db->jname.c_str(), NAME_LENGTH);
+	}
+#endif // Pandas_Fix_SetUnitData_Forget_Reset_After_Monster_Dead
+
+// =======================================================================
+// 非 md->base_status 中的数据但可以被 setunitdata 修改的属性重置 - 到此结束
+// =======================================================================
+
 	if (md->lootitems)
 		memset(md->lootitems, 0, sizeof(*md->lootitems));
 

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1254,9 +1254,15 @@ int mob_spawn (struct mob_data *md)
 #ifdef Pandas_Fix_SetUnitData_Forget_Reset_After_Monster_Dead
 	if (md->db) {
 		if (battle_config.override_mob_names == 1)
-			memcpy(md->name, md->db->name.c_str(), NAME_LENGTH);
-		else
-			memcpy(md->name, md->db->jname.c_str(), NAME_LENGTH);
+			memcpy(md->name, md->db->name.c_str(), sizeof(md->name));
+		else if (battle_config.override_mob_names == 2)
+			memcpy(md->name, md->db->jname.c_str(), sizeof(md->name));
+		else {
+			if (md->spawn)
+				memcpy(md->name, md->spawn->name, sizeof(md->name));
+			else
+				memcpy(md->name, md->db->jname.c_str(), sizeof(md->name));
+		}
 	}
 #endif // Pandas_Fix_SetUnitData_Forget_Reset_After_Monster_Dead
 

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2999,6 +2999,13 @@ void unit_dataset(struct block_list *bl)
 	ud->attackabletime =
 	ud->canact_tick    =
 	ud->canmove_tick   = gettick();
+
+#ifdef Pandas_Struct_Unit_CommonData
+	struct s_unit_common_data* ucd = status_get_ucd(bl);
+	if (ucd) {
+		memset(ucd, 0, sizeof(struct s_unit_common_data));
+	}
+#endif // Pandas_Struct_Unit_CommonData
 }
 
 /**


### PR DESCRIPTION
## 操作方法

- 确保你的角色一击能杀死“波波利”（比如将 str 设置为 1000）
- 使用 "/nc" 关闭自动攻击
- 前往 `prontera,156,132` 杀死“波波利”
- 等待 5 秒后他会重生
- 观察重生之后的魔物，是否携带光环，名称是否正确

## 现在的表现

- 新重生的波波利，名字还是“上辈子”的样子
- 同时也携带了“上辈子”的光环

## 预期表现

- 是一个干干净净的“波波利”

## 重现脚本

```c
prontera,156,132	monster	PoPoring	1031,1,5,0

-	script	OnPCAttackFilter#CrazyBoss	-1,{
end;

OnPCAttackExpress:
	.@Gid = @attack_target_gid;
	
	// 被攻击的不是魔物则无需处理
	if(@attack_target_mobid == 0) end;
	
	// 被一击必杀则无需处理
	if(!unitexists(.@Gid, 1)) end;
	
	// 检查被攻击魔物是否已被处理过
	.@is2 = inarray($@crazy_mob_gid, .@Gid);
	
	// 若没有被处理过
	if(.@is2 == -1){
	
		// 记录魔物的 gid 到数组中, 表示它被处理过
		.@size = getarraysize($@crazy_mob_gid);
		$@crazy_mob_gid[.@size] = .@Gid;
		
		// 随机提升倍率
		.@bonus_tmp = rand(2, 10);
		
		// 获取魔物现在的名称
		.@mob_name$ = getunitname(.@Gid);
		
		// 在他的名称前添加个前缀
		setunitname .@Gid, "["+.@bonus_tmp+"倍]"+.@mob_name$;
		
		// 被处理过的魔物添加个光环
		unitaura .@Gid, 1063;
	}
end;

OnUnitKillExpress:
	//击杀者若不是玩家，死亡对象不是魔物，则结束程序
	if(getunittype($@killer_gid) != BL_PC && getunittype($@killed_gid) != BL_MOB) end;		
	
	// 判断是否为处理过的魔物
	.@idx = inarray($@crazy_mob_gid, $@killed_gid);
	
	// 若处理过, 则将魔物的 gid 从数组中移除 (因为它死了)
	if(.@idx != -1) {
		deletearray $@crazy_mob_gid[.@idx], 1;
	}	
end;
}
```