### PR TITLE
修正 prompt 选择取消后使用 close 系列指令会导致报错的问题

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1008,7 +1008,12 @@
 	//
 	// 特别感谢 "差记性的小北" 指出此问题
 	#define Pandas_Fix_SetUnitData_Forget_Reset_After_Monster_Dead
-	
+
+	// 修正玩家在 prompt 菜单中选择取消后,
+	// 后续脚本中若调用 close 系列指令会导致报错的问题 [Sola丶小克]
+	//
+	// 特别感谢 "差记性的小北" 指出此问题
+	#define Pandas_Fix_Prompt_Cancel_Combine_Close_Error
 #endif // Pandas_Bugfix
 
 // ============================================================================

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -10139,6 +10139,9 @@ void pc_close_npc(map_session_data *sd,int flag)
 		}
 		sd->state.menu_or_input = 0;
 		sd->npc_menu = 0;
+#ifdef Pandas_Fix_Prompt_Cancel_Combine_Close_Error
+		sd->npc_menu_npcid = 0;
+#endif // Pandas_Fix_Prompt_Cancel_Combine_Close_Error
 		sd->npc_shopid = 0;
 #ifdef SECURE_NPCTIMEOUT
 		if( sd->npc_idle_timer != INVALID_TIMER ){

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -561,6 +561,9 @@ public:
 	std::vector<int> areanpc, npc_ontouch_;	///< Array of OnTouch and OnTouch_ NPC ID
 	int npc_item_flag; //Marks the npc_id with which you can use items during interactions with said npc (see script command enable_itemuse)
 	int npc_menu; // internal variable, used in npc menu handling
+#ifdef Pandas_Fix_Prompt_Cancel_Combine_Close_Error
+	int npc_menu_npcid; // 当 prompt 菜单项取消时, 记录 npc_id
+#endif // Pandas_Fix_Prompt_Cancel_Combine_Close_Error
 	int npc_amount;
 	struct script_state *st;
 #ifdef Pandas_ScriptEngine_MutliStackBackup

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -6030,6 +6030,9 @@ BUILDIN_FUNC(menu)
 
 		StringBuf_Init(&buf);
 		sd->npc_menu = 0;
+#ifdef Pandas_Fix_Prompt_Cancel_Combine_Close_Error
+		sd->npc_menu_npcid = 0;
+#endif // Pandas_Fix_Prompt_Cancel_Combine_Close_Error
 		for( i = 2; i < script_lastdata(st); i += 2 )
 		{
 			struct script_data* data;
@@ -6149,6 +6152,9 @@ BUILDIN_FUNC(select)
 
 		StringBuf_Init(&buf);
 		sd->npc_menu = 0;
+#ifdef Pandas_Fix_Prompt_Cancel_Combine_Close_Error
+		sd->npc_menu_npcid = 0;
+#endif // Pandas_Fix_Prompt_Cancel_Combine_Close_Error
 		for( i = 2; i <= script_lastdata(st); ++i ) {
 			text = script_getstr(st, i);
 
@@ -6228,6 +6234,9 @@ BUILDIN_FUNC(prompt)
 
 		StringBuf_Init(&buf);
 		sd->npc_menu = 0;
+#ifdef Pandas_Fix_Prompt_Cancel_Combine_Close_Error
+		sd->npc_menu_npcid = 0;
+#endif // Pandas_Fix_Prompt_Cancel_Combine_Close_Error
 		for( i = 2; i <= script_lastdata(st); ++i )
 		{
 			text = script_getstr(st, i);


### PR DESCRIPTION
 感谢 "差记性的小北" 反馈此问题

## 测试脚本
```c
prontera,153,155,4	script	testttttt	123,{
	mes "很高兴为你服务！";
	.@s = prompt("投注","兑奖","说明");
	if(.@s == 3){
		mes "3";
	}else if(.@s == 1){
		mes "1";
	}else if(.@s == 2){
		mes "2";
	}else{
		mes "其他";
	}
	close;
}
```

## 重现方法
与测试 npc 对话，出来的菜单中直接点【取消】

## 预期表现
各项功能一切正常

## 实际情况
地图服务器跳出来一个调试信息：
```
[调试]: npc_scriptcont: testttttt (sd->npc_id=110026153) is not 'Unknown NPC' (id=0).
```

## 分析一下
同样的脚本使用 select 菜单则不存在问题，因为当 select 被取消后脚本将中断。
但 prompt 菜单被取消后脚本依然会继续执行，执行到 close 脚本指令的时候，会暗示客户端：
`关闭聊天窗口需要给我发一个 clif_parse_NpcCloseClicked 封包`
但此时发现送来的封包中 npc_id 是 0（客户端内部可能把 npc_id 清理掉了）

## 补丁方案
为了避免对后续流程造成不可预期的其他影响，在菜单被取消的时候我们记录一下 npc_id；随后在出现 prompt 取消的这种情况时，将优先使用备份的 npc_id 来进行后续流程