### PR TITLE
修正脚本控制的商店在特定情况下存在的报错问题

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1011,6 +1011,13 @@
 	//
 	// 特别感谢 "差记性的小北" 指出此问题
 	#define Pandas_Fix_Prompt_Cancel_Combine_Close_Error
+
+	// 修正脚本控制的商店在特定情况下存在的报错问题 [Sola丶小克]
+	// 只要在 npcshopattach + callshop 之前调用了一个 mes 并且不 close 它,
+	// 那么当玩家完成商店中的交易操作后就会出现 npc_scriptcont 报错.
+	//
+	// 特别感谢 "HongShin" 指出此问题
+	#define Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
 #endif // Pandas_Bugfix
 
 // ============================================================================

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -11606,6 +11606,10 @@ void clif_parse_LoadEndAck(int fd,map_session_data *sd)
 	// reset the callshop flag if the player changes map
 	sd->state.callshop = 0;
 
+#ifdef Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
+	sd->callshop_master_npcid = 0;
+#endif // Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
+
 	if(map_addblock(&sd->bl))
 		return;
 	clif_spawn(&sd->bl);

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -2679,7 +2679,8 @@ bool npc_scriptcont(map_session_data* sd, int id, bool closing){
 		TBL_NPC* nd_sd = (TBL_NPC*)map_id2bl(sd->npc_id);
 
 #ifdef Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
-		if (!id && sd->st && sd->st->mes_active && sd->npc_id == sd->callshop_master_npcid) {
+		if (!id && sd->st && sd->st->mes_active &&
+			sd->npc_id != 0 && sd->npc_id == sd->callshop_master_npcid) {
 			// 若客户端传来的 npc_id (即: id 变量) 的值为 0
 			// 并且玩家当前存在一个 mes 对话框 (sd->st->mes_active 为 1),
 			// 以及通过 npcshopattach + callshop 打开了脚本控制的商店 (sd->callshop_master_npcid 有值),
@@ -3197,7 +3198,7 @@ static int npc_buylist_sub(map_session_data* sd, std::vector<s_npc_buy_list>& it
 	}
 
 #ifdef Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
-	if (nd) {
+	if (sd && nd) {
 		sd->callshop_master_npcid = nd->bl.id;
 	}
 #endif // Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
@@ -3458,7 +3459,7 @@ static int npc_selllist_sub(map_session_data* sd, int list_length, PACKET_CZ_PC_
 	}
 
 #ifdef Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
-	if (nd) {
+	if (sd && nd) {
 		sd->callshop_master_npcid = nd->bl.id;
 	}
 #endif // Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -2678,6 +2678,17 @@ bool npc_scriptcont(map_session_data* sd, int id, bool closing){
 	if( id != sd->npc_id ){
 		TBL_NPC* nd_sd = (TBL_NPC*)map_id2bl(sd->npc_id);
 
+#ifdef Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
+		if (!id && sd->st && sd->st->mes_active && sd->npc_id == sd->callshop_master_npcid) {
+			// 若客户端传来的 npc_id (即: id 变量) 的值为 0
+			// 并且玩家当前存在一个 mes 对话框 (sd->st->mes_active 为 1),
+			// 以及通过 npcshopattach + callshop 打开了脚本控制的商店 (sd->callshop_master_npcid 有值),
+			// 并且对话中的 npc_id 与 callshop_master_npcid 一致,
+			// 那么这里直接跳过执行即可, 无需报错.
+			return true;
+		}
+#endif // Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
+
 		ShowDebug("npc_scriptcont: %s (sd->npc_id=%d) is not %s (id=%d).\n",
 			nd_sd?(char*)nd_sd->name:"'Unknown NPC'", (int)sd->npc_id,
 			nd?(char*)nd->name:"'Unknown NPC'", (int)id);
@@ -3185,6 +3196,12 @@ static int npc_buylist_sub(map_session_data* sd, std::vector<s_npc_buy_list>& it
 		script_setarray_pc( sd, "@bought_quantity", i, item_list[i].qty, &key_amount );
 	}
 
+#ifdef Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
+	if (nd) {
+		sd->callshop_master_npcid = nd->bl.id;
+	}
+#endif // Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
+
 	// invoke event
 	snprintf(npc_ev, ARRAYLENGTH(npc_ev), "%s::%s", nd->exname, script_config.onbuy_event_name);
 	npc_event(sd, npc_ev, 0);
@@ -3439,6 +3456,12 @@ static int npc_selllist_sub(map_session_data* sd, int list_length, PACKET_CZ_PC_
 			}
 		}
 	}
+
+#ifdef Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
+	if (nd) {
+		sd->callshop_master_npcid = nd->bl.id;
+	}
+#endif // Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
 
 	// invoke event
 	snprintf(npc_ev, ARRAYLENGTH(npc_ev), "%s::%s", nd->exname, script_config.onsell_event_name);

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -562,8 +562,11 @@ public:
 	int npc_item_flag; //Marks the npc_id with which you can use items during interactions with said npc (see script command enable_itemuse)
 	int npc_menu; // internal variable, used in npc menu handling
 #ifdef Pandas_Fix_Prompt_Cancel_Combine_Close_Error
-	int npc_menu_npcid; // 当 prompt 菜单项取消时, 记录 npc_id
+	int npc_menu_npcid;
 #endif // Pandas_Fix_Prompt_Cancel_Combine_Close_Error
+#ifdef Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
+	int callshop_master_npcid;
+#endif // Pandas_Fix_ScriptControl_Shop_Missing_NpcID_Error
 	int npc_amount;
 	struct script_state *st;
 #ifdef Pandas_ScriptEngine_MutliStackBackup

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11367,7 +11367,7 @@ BUILDIN_FUNC(end)
 	if( st->mes_active )
 		st->mes_active = 0;
 
-	if (sd) {
+	if (sd){
 		if (sd->state.callshop == 0)
 			clif_scriptclose(sd, st->oid); // If a menu/select/prompt is active, close it.
 		else 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11367,7 +11367,7 @@ BUILDIN_FUNC(end)
 	if( st->mes_active )
 		st->mes_active = 0;
 
-	if (sd){
+	if (sd) {
 		if (sd->state.callshop == 0)
 			clif_scriptclose(sd, st->oid); // If a menu/select/prompt is active, close it.
 		else 


### PR DESCRIPTION
 感谢 "HongShin" 反馈此问题

## 测试脚本
```c
prontera,150,175,4	script	fsfsfsf	100,{
    mes "1";
    npcshopattach "testshop", 1;
    callshop "testshop", 1;
    end;
    
OnBuyItem:
    mes "bought_quantity: "+@bought_quantity;
    next;
    mes "bought_nameid: "+@bought_nameid;
    end;
}

-	shop	testshop	-1,no,909:100,910:100
```

## 重现方法
与测试 npc 对话，拖拽商品进行购买

## 预期表现
各项功能一切正常

## 实际情况
地图服务器跳出来一个调试信息：
```
[调试]: npc_scriptcont: testttttt (sd->npc_id=110026153) is not 'Unknown NPC' (id=0).
```
