### PR TITLE
与NPC交互时是否对交互超时进行判断 [聽風]

### DIFF
--- a/conf/battle/pandas.conf
+++ b/conf/battle/pandas.conf
@@ -489,4 +489,10 @@ mob_default_damagemotion: 0
 // 默认值为: yes
 mob_setunitdata_persistence: yes
 
+// 与NPC交互时是否对交互超时进行判断 [聽風]
+// 如果设置此选项为 no 则玩家与NPC对话永远不会超时
+
+// 默认值为: yes
+npc_timeout: yes
+
 // PYHELP - BATTLECONFIG - INSERT POINT - <Section 4>

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -369,6 +369,10 @@
 	// 是否启用 mob_setunitdata_persistence 配置选项及其功能 [Sola丶小克]
 	// 此选项用于控制是否高优先级持久化保存 setunitdata 对魔物的设置
 	#define Pandas_BattleConfig_Mob_SetUnitData_Persistence
+
+	// 是否启用 npc_timeout 配置选项及其功能 [聽風]
+	// 与NPC交互时是否对交互超时进行判断
+	#define Pandas_BattleConfig_Npc_Timeout
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 1>
 #endif // Pandas_BattleConfigure
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -10661,6 +10661,9 @@ static const struct _battle_data {
 #ifdef Pandas_BattleConfig_Mob_SetUnitData_Persistence
 	{ "mob_setunitdata_persistence",        &battle_config.mob_setunitdata_persistence,     1,      0,      1,              },
 #endif // Pandas_BattleConfig_Mob_SetUnitData_Persistence
+#ifdef Pandas_BattleConfig_npc_timeout
+	{ "npc_timeout",    &battle_config.npc_timeout,    0,    0,    1,    },
+#endif // Pandas_BattleConfig_npc_timeout
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 3>
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -815,6 +815,9 @@ struct Battle_Config
 #ifdef Pandas_BattleConfig_Mob_SetUnitData_Persistence
 	int mob_setunitdata_persistence;		// 是否高优先级持久化保存 setunitdata 对魔物的设置
 #endif // Pandas_BattleConfig_Mob_SetUnitData_Persistence
+#ifdef Pandas_BattleConfig_Npc_Timeout	// 与NPC交互时是否对交互超时进行判断
+	int npc_timeout;
+#endif // Pandas_BattleConfig_Npc_Timeout
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 2>
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -1454,7 +1454,11 @@ TIMER_FUNC(npc_secure_timeout_timer){
 	}
 
 	if( DIFF_TICK(cur_tick,sd->npc_idle_tick) > (timeout*1000) ) {
-		pc_close_npc(sd,1);
+#ifdef Pandas_BattleConfig_Npc_Timeout
+		if (battle_config.npc_timeout) {
+			pc_close_npc(sd, 1);
+		}
+#endif // Pandas_BattleConfig_Npc_Timeout
 	} else if(sd->st && (sd->st->state == END || sd->st->state == CLOSE)){
 		// stop timer the script is already ending
 		if( sd->npc_idle_timer != INVALID_TIMER ){


### PR DESCRIPTION
conf\battle\pandas.conf


// 与NPC交互时是否对交互超时进行判断 [聽風]
// 如果设置此选项为 no 则玩家与NPC对话永远不会超时

// 默认值为: yes
npc_timeout: yes