### PR TITLE
当自己拥有 sc 状态的时候, 会增加 bonus 参数为 x,r,n [聽風]

### DIFF
--- a/doc/pandas_bonus.txt
+++ b/doc/pandas_bonus.txt
@@ -365,3 +365,81 @@ bonus4 bStatusAddDamageRate,sc,n,r,bf;
 	- bonus bAbsorbDmgMaxHP,n;
 
 --------------------------------------------------------------
+
+bonus3 bStatusAddBonus,sc,bonus,n;
+
+当自己拥有 sc 状态的时候, 会增加 bonus 参数为 n [聽風]
+
+参数说明:
+	sc			SC 状态编号, 支持常量
+				例如: 天使之赐福状态的常量是 SC_BLESSING
+
+	bonus		bonus 效果调整器
+				例如: STR + n(bonus bStr,n;)的效果调整器是 bStr
+
+	n			增加的数值
+				可被叠加, 支持负数, 若传递负数则表示扣减.
+
+使用范例:
+	//人物拥有 天使赐福状态时 额外增加 20点 STR
+	bonus3 bStatusAddBonus,SC_BLESSING,bStr,20;
+	
+注意事项:
+	本条效果调整器仅支持 bonus 类
+	且 n 参数只支持数值或常量
+
+--------------------------------------------------------------
+
+bonus4 bStatusAddBonus,sc,bonus,r,n;
+
+当自己拥有 sc 状态的时候, 会增加 bonus 参数为 r,n [聽風]
+
+参数说明:
+	sc			SC 状态编号, 支持常量
+				例如: 天使之赐福状态的常量是 SC_BLESSING
+
+	bonus		bonus2 效果调整器
+				例如: 治愈技能 sk 的治愈效果增加 n% (bonus2 bSkillHeal,sk,n;)的效果调整器是 bSkillHeal
+
+	r			bonus2中的 第一个 参数
+
+	n			增加的数值
+				可被叠加, 支持负数, 若传递负数则表示扣减.
+
+使用范例:
+	//人物拥有 天使赐福状态时 额外增加 治愈术回复量 100% (治愈术技能ID为 28)
+	bonus4 bStatusAddBonus,SC_BLESSING,bSkillHeal,28,100;
+	
+注意事项:
+	本条效果调整器仅支持 bonus2 类
+	且 r,n 参数只支持数值或常量
+
+--------------------------------------------------------------
+
+bonus5 bStatusAddBonus,sc,bonus,x,r,n;
+
+当自己拥有 sc 状态的时候, 会增加 bonus 参数为 x,r,n [聽風]
+
+参数说明:
+	sc			SC 状态编号, 支持常量
+				例如: 天使之赐福状态的常量是 SC_BLESSING
+
+	bonus		bonus3 效果调整器
+				例如: 攻击时有 n/10% 的机率自动咏唱 y 级技能 sk (bonus3 bAutoSpell,sk,y,n;)的效果调整器是 bAutoSpell
+
+	x			bonus3中的 第一个 参数
+	
+	r			bonus3中的 第二个 参数
+
+	n			增加的数值
+				可被叠加, 支持负数, 若传递负数则表示扣减.
+
+使用范例:
+	//人物拥有 天使赐福状态时 额外增加 普通攻击 10% 自动念咒 火箭术 10级 (火箭术技能ID为 19)
+	bonus5 bStatusAddBonus,SC_BLESSING,bAutoSpell,19,10,100;
+	
+注意事项:
+	本条效果调整器仅支持 bonus3 类
+	且 x,r,n 参数只支持数值或常量
+
+--------------------------------------------------------------

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1800,6 +1800,17 @@
 	// 变量位置: map_session_data.bonus / 变量名称: absorb_dmg_trigger_hpratio, absorb_dmg_cap_ratio
 	// 使用原型: bonus2 bAbsorbDmgMaxHP,n,x;
 	#define Pandas_Bonus2_bAbsorbDmgMaxHP
+
+	// 是否启用 bonus3 bStatusAddBonus 效果调整器 [聽風]
+	// 当自己拥有 sc 状态的时候, 会增加 bonus 参数为 n
+	// 当自己拥有 sc 状态的时候, 会增加 bonus 参数为 r,n
+	// 当自己拥有 sc 状态的时候, 会增加 bonus 参数为 x,r,n
+	// 常量名称: SP_PANDAS_STATUSADDBONUS / 调整器名称: bStatusAddBonus
+	// 变量位置: map_session_data / 变量名称: statsadd_bonus3, statsadd_bonus4, statsadd_bonus5
+	// 使用原型: bonus3 bStatusAddBonus,sc,bonus,n;
+	//           bonus4 bStatusAddBonus,sc,bonus,r,n;
+	//           bonus5 bStatusAddBonus,sc,bonus,x,r,n;
+	#define Pandas_Bonus3_bStatusAddBonus
 	// PYHELP - BONUS - INSERT POINT - <Section 1>
 #endif // Pandas_Bonuses
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -613,6 +613,9 @@ enum _sp {
 	#ifdef Pandas_Bonus3_bFinalAddClass
 		SP_PANDAS_FINALADDCLASS,	// 调整器名称: bFinalAddClass / 说明: 使用 bf 攻击时 c 类型目标时增加 x% 的伤害 (在最终伤害上全段修正)
 	#endif // Pandas_Bonus3_bFinalAddClass
+	#ifdef Pandas_Bonus3_bStatusAddBonus
+		SP_PANDAS_STATUSADDBONUS,	// 调整器名称: bStatusAddBonus / 说明: 当自己拥有 sc 状态的时候, 会增加 bonus 参数为 n / r,n / x,r,n 
+	#endif // Pandas_Bonus3_bStatusAddBonus
 	// PYHELP - BONUS - INSERT POINT - <Section 2>
 	SP_PANDAS_EXTEND_BONUS_END,
 #endif // Pandas_Bonuses

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -3253,6 +3253,92 @@ static void pc_bonus_final_damage(std::vector<s_final_damage>& dmgrule, int8 typ
 }
 #endif // defined(Pandas_Bonus3_bFinalAddRace) || defined(Pandas_Bonus3_bFinalAddClass)
 
+#ifdef Pandas_Bonus3_bStatusAddBonus
+static void pc_bonus_status_addbonus3(std::vector<s_sc_addbonus3>& dmgrule, enum sc_type sc, short bonus, int val)
+{
+	if (dmgrule.size() == MAX_PC_BONUS) {
+		ShowWarning("pc_bonus_status_addbonus3: Reached max (%d) number of add status damage rule per character!\n", MAX_PC_BONUS);
+		return;
+	}
+
+	if (!bonus)
+		return;
+
+	for (auto& it : dmgrule) {
+		if (it.type == sc) {
+			it.bonus = bonus;
+			it.val = rathena::util::safe_addition_cap(it.val, val, INT_MAX);
+			return;
+		}
+	}
+
+	struct s_sc_addbonus3 entry = {};
+
+	entry.type = sc;
+	entry.bonus = bonus;
+	entry.val = val;
+
+	dmgrule.push_back(entry);
+}
+static void pc_bonus_status_addbonus4(std::vector<s_sc_addbonus4>& dmgrule, enum sc_type sc, short bonus, int r, int val)
+{
+	if (dmgrule.size() == MAX_PC_BONUS) {
+		ShowWarning("pc_bonus_status_addbonus4: Reached max (%d) number of add status damage rule per character!\n", MAX_PC_BONUS);
+		return;
+	}
+
+	if (!bonus)
+		return;
+
+	for (auto& it : dmgrule) {
+		if (it.type == sc) {
+			it.bonus = bonus;
+			it.r = r;
+			it.val = rathena::util::safe_addition_cap(it.val, val, INT_MAX);
+			return;
+		}
+	}
+
+	struct s_sc_addbonus4 entry = {};
+
+	entry.type = sc;
+	entry.bonus = bonus;
+	entry.r = r;
+	entry.val = val;
+
+	dmgrule.push_back(entry);
+}
+static void pc_bonus_status_addbonus5(std::vector<s_sc_addbonus5>& dmgrule, enum sc_type sc, short bonus, int x, int r, int val)
+{
+	if (dmgrule.size() == MAX_PC_BONUS) {
+		ShowWarning("pc_bonus_status_addbonus5: Reached max (%d) number of add status damage rule per character!\n", MAX_PC_BONUS);
+		return;
+	}
+
+	if (!bonus)
+		return;
+
+	for (auto& it : dmgrule) {
+		if (it.type == sc) {
+			it.bonus = bonus;
+			it.x = x;
+			it.r = r;
+			it.val = rathena::util::safe_addition_cap(it.val, val, INT_MAX);
+			return;
+		}
+	}
+
+	struct s_sc_addbonus5 entry = {};
+
+	entry.type = sc;
+	entry.bonus = bonus;
+	entry.x = x;
+	entry.r = r;
+	entry.val = val;
+
+	dmgrule.push_back(entry);
+}
+#endif // Pandas_Bonus3_bStatusAddBonus
 /**
  * Adjust/add drop rate modifier for player
  * @param drop: Player's sd->add_drop (struct s_add_drop)
@@ -5339,6 +5425,12 @@ void pc_bonus3(map_session_data *sd,int type,int type2,int type3,int val)
 		pc_bonus_final_damage(sd->finaladd_class[type2], type2, val, type3);
 		break;
 #endif // Pandas_Bonus3_bFinalAddClass
+#ifdef Pandas_Bonus3_bStatusAddBonus
+	case SP_PANDAS_STATUSADDBONUS: // bonus3 bStatusAddBonus,sc,bonus,n;
+		if (sd->state.lr_flag != 2)
+			pc_bonus_status_addbonus3(sd->statsadd_bonus3, (sc_type)type2, type3, val);
+		break;
+#endif // Pandas_Bonus3_bStatusAddBonus
 		// PYHELP - BONUS - INSERT POINT - <Section 8>
 	default:
 #ifdef Pandas_NpcExpress_STATCALC
@@ -5446,6 +5538,12 @@ void pc_bonus4(map_session_data *sd,int type,int type2,int type3,int type4,int v
 			pc_bonus_status_damage(sd->status_damagerate_adjust, (sc_type)type2, type4, val, type3);
 		break;
 #endif // Pandas_Bonus4_bStatusAddDamageRate
+#ifdef Pandas_Bonus3_bStatusAddBonus
+	case SP_PANDAS_STATUSADDBONUS: // bonus4 bStatusAddBonus,sc,bonus,r,n;
+		if (sd->state.lr_flag != 2)
+			pc_bonus_status_addbonus4(sd->statsadd_bonus4, (sc_type)type2, type3, type4, val);
+		break;
+#endif // Pandas_Bonus3_bStatusAddBonus
 		// PYHELP - BONUS - INSERT POINT - <Section 9>
 	default:
 #ifdef Pandas_NpcExpress_STATCALC
@@ -5505,6 +5603,12 @@ void pc_bonus5(map_session_data *sd,int type,int type2,int type3,int type4,int t
 		if( sd->state.lr_flag != 2 )
 			pc_bonus_addeff_onskill(sd->addeff_onskill, (sc_type)type3, type4, type2, type5, val);
 		break;
+#ifdef Pandas_Bonus3_bStatusAddBonus
+	case SP_PANDAS_STATUSADDBONUS: // bonus5 bStatusAddBonus,sc,bonus,x,r,n;
+		if (sd->state.lr_flag != 2)
+			pc_bonus_status_addbonus5(sd->statsadd_bonus5, (sc_type)type2, type3, type4, type5, val);
+		break;
+#endif // Pandas_Bonus3_bStatusAddBonus
 		// PYHELP - BONUS - INSERT POINT - <Section 10>
 
 	default:

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -265,6 +265,24 @@ struct s_final_damage {
 };
 #endif // defined(Pandas_Bonus3_bFinalAddRace) || defined(Pandas_Bonus3_bFinalAddClass)
 
+#ifdef Pandas_Bonus3_bStatusAddBonus
+struct s_sc_addbonus3 {
+	sc_type type;
+	short bonus;
+	int val;
+};
+struct s_sc_addbonus4 {
+	sc_type type;
+	short bonus;
+	int val, r;
+};
+struct s_sc_addbonus5 {
+	sc_type type;
+	short bonus;
+	int val, x, r;
+};
+#endif // Pandas_Bonus3_bStatusAddBonus
+
 /// Miscellaneous item bonus struct
 struct s_item_bonus {
 	uint16 id;
@@ -699,6 +717,11 @@ public:
 #ifdef Pandas_Bonus3_bFinalAddClass
 	std::vector<s_final_damage> finaladd_class[CLASS_MAX];
 #endif // Pandas_Bonus3_bFinalAddClass
+#ifdef Pandas_Bonus3_bStatusAddBonus
+	std::vector<s_sc_addbonus3> statsadd_bonus3;
+	std::vector<s_sc_addbonus4> statsadd_bonus4;
+	std::vector<s_sc_addbonus5> statsadd_bonus5;
+#endif // Pandas_Bonus3_bStatusAddBonus
 
 	// zeroed structures start here
 	struct s_regen {

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -1243,6 +1243,10 @@
 	// 使用 bf 攻击时 c 类型目标时增加 x% 的伤害 (在最终伤害上全段修正)
 	export_constant2("bFinalAddClass", SP_PANDAS_FINALADDCLASS);
 #endif // Pandas_Bonus3_bFinalAddClass
+#ifdef Pandas_Bonus3_bStatusAddBonus
+	// 当自己拥有 sc 状态的时候, 会增加 bonus 参数为 n / r,n / x,r,n
+	export_constant2("bStatusAddBonus", SP_PANDAS_STATUSADDBONUS);
+#endif // Pandas_Bonus3_bStatusAddBonus
 	// PYHELP - BONUS - INSERT POINT - <Section 3>
 
 #endif // Pandas_Bonuses

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -3899,6 +3899,12 @@ int status_calc_pc_sub(map_session_data* sd, uint8 opt)
 	sd->skillnorequire.clear();
 #endif // Pandas_Bonus2_bSkillNoRequire
 
+#ifdef Pandas_Bonus3_bStatusAddBonus
+	sd->statsadd_bonus3.clear();
+	sd->statsadd_bonus4.clear();
+	sd->statsadd_bonus5.clear();
+#endif // Pandas_Bonus3_bStatusAddBonus
+
 #ifdef Pandas_Struct_Map_Session_Data_MultiCatchTargetClass
 	sd->pandas.multi_catch_target_class.clear();
 #endif // Pandas_Struct_Map_Session_Data_MultiCatchTargetClass
@@ -3935,6 +3941,24 @@ int status_calc_pc_sub(map_session_data* sd, uint8 opt)
 	npc_script_event(sd, NPCE_STATCALC);
 	running_npc_stat_calc_event = false;
 #endif // Pandas_NpcExpress_STATCALC
+
+#ifdef Pandas_Bonus3_bStatusAddBonus
+	for (auto& it : sd->statsadd_bonus3) {
+		if (!sc->getSCE(it.type))
+			continue;
+		pc_bonus(sd, it.bonus, it.val);
+	}
+	for (auto& it : sd->statsadd_bonus4) {
+		if (!sc->getSCE(it.type))
+			continue;
+		pc_bonus2(sd, it.bonus, it.r, it.val);
+	}
+	for (auto& it : sd->statsadd_bonus5) {
+		if (!sc->getSCE(it.type))
+			continue;
+		pc_bonus3(sd, it.bonus, it.x, it.r, it.val);
+	}
+#endif // Pandas_Bonus3_bStatusAddBonus
 
 	// Parse equipment
 	for (i = 0; i < EQI_MAX; i++) {
@@ -6474,7 +6498,7 @@ void status_calc_bl_(struct block_list* bl, std::bitset<SCB_MAX> flag, uint8 opt
 {
 	struct status_data b_status; // Previous battle status
 	struct status_data* status; // Pointer to current battle status
-
+	
 	if (bl->type == BL_PC) {
 		map_session_data *sd = BL_CAST(BL_PC, bl);
 
@@ -6491,7 +6515,7 @@ void status_calc_bl_(struct block_list* bl, std::bitset<SCB_MAX> flag, uint8 opt
 	// Remember previous values
 	status = status_get_status_data(bl);
 	memcpy(&b_status, status, sizeof(struct status_data));
-
+	
 #ifdef Pandas_Persistent_SetUnitData_For_Monster_StatusData
 	struct status_data previous_b_status = { 0 };
 	bool backed_up = false;
@@ -6515,6 +6539,22 @@ void status_calc_bl_(struct block_list* bl, std::bitset<SCB_MAX> flag, uint8 opt
 		case BL_NPC: status_calc_npc_(BL_CAST(BL_NPC,bl), opt); break;
 		}
 	}
+
+#ifdef Pandas_Bonus3_bStatusAddBonus
+	
+		/*
+		* 此处应为检测是否拥有对应SC，如果拥有则强制 status_calc_pc_
+		* 但是因为 rA官方的 SC刷新有BUG，此处等待克总修复，或其他……
+		* 大致执行代码如下
+		*
+		if (bl->type == BL_PC) {
+			for (auto& it : sd->statsadd_bonus3) {
+				if (sc->getSCE(it.type))
+					status_calc_pc_(BL_CAST(BL_PC,bl), opt);
+			}
+		}
+		*/
+#endif // Pandas_Bonus3_bStatusAddBonus
 
 #ifdef Pandas_Persistent_SetUnitData_For_Monster_StatusData
 	// 如果是魔物且魔物曾经被 setunitdata 设置过一些字段,


### PR DESCRIPTION
**因为 rA官方的 SC刷新有BUG，本Pull并不能直接使用。但不影响测试。
需等待克总在主分支修复，或其他……**

--------------------------------------------------------------

bonus3 bStatusAddBonus,sc,bonus,n;

当自己拥有 sc 状态的时候, 会增加 bonus 参数为 n [聽風]

参数说明:
	sc			SC 状态编号, 支持常量
				例如: 天使之赐福状态的常量是 SC_BLESSING

	bonus		bonus 效果调整器
				例如: STR + n(bonus bStr,n;)的效果调整器是 bStr

	n			增加的数值
				可被叠加, 支持负数, 若传递负数则表示扣减.

使用范例:
	//人物拥有 天使赐福状态时 额外增加 20点 STR
	bonus3 bStatusAddBonus,SC_BLESSING,bStr,20;
	
注意事项:
	本条效果调整器仅支持 bonus 类
	且 n 参数只支持数值或常量

--------------------------------------------------------------

bonus4 bStatusAddBonus,sc,bonus,r,n;

当自己拥有 sc 状态的时候, 会增加 bonus 参数为 r,n [聽風]

参数说明:
	sc			SC 状态编号, 支持常量
				例如: 天使之赐福状态的常量是 SC_BLESSING

	bonus		bonus2 效果调整器
				例如: 治愈技能 sk 的治愈效果增加 n% (bonus2 bSkillHeal,sk,n;)的效果调整器是 bSkillHeal

	r			bonus2中的 第一个 参数

	n			增加的数值
				可被叠加, 支持负数, 若传递负数则表示扣减.

使用范例:
	//人物拥有 天使赐福状态时 额外增加 治愈术回复量 100% (治愈术技能ID为 28)
	bonus4 bStatusAddBonus,SC_BLESSING,bSkillHeal,28,100;
	
注意事项:
	本条效果调整器仅支持 bonus2 类
	且 r,n 参数只支持数值或常量

--------------------------------------------------------------

bonus5 bStatusAddBonus,sc,bonus,x,r,n;

当自己拥有 sc 状态的时候, 会增加 bonus 参数为 x,r,n [聽風]

参数说明:
	sc			SC 状态编号, 支持常量
				例如: 天使之赐福状态的常量是 SC_BLESSING

	bonus		bonus3 效果调整器
				例如: 攻击时有 n/10% 的机率自动咏唱 y 级技能 sk (bonus3 bAutoSpell,sk,y,n;)的效果调整器是 bAutoSpell

	x			bonus3中的 第一个 参数
	
	r			bonus3中的 第二个 参数

	n			增加的数值
				可被叠加, 支持负数, 若传递负数则表示扣减.

使用范例:
	//人物拥有 天使赐福状态时 额外增加 普通攻击 10% 自动念咒 火箭术 10级 (火箭术技能ID为 19)
	bonus5 bStatusAddBonus,SC_BLESSING,bAutoSpell,19,10,100;
	
注意事项:
	本条效果调整器仅支持 bonus3 类
	且 x,r,n 参数只支持数值或常量

--------------------------------------------------------------