### PR TITLE
解决 Linux 使用 Ctrl+C 会直接中断程序的问题

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -3257,6 +3257,9 @@ void CharacterServer::finalize(){
 
 /// Called when a terminate signal is received.
 void CharacterServer::handle_shutdown(){
+#ifdef Pandas_UserExperience_Linux_Ctrl_C_WarpLine
+	printf("\n");
+#endif // Pandas_UserExperience_Linux_Ctrl_C_WarpLine
 	ShowStatus("Shutting down...\n");
 	// TODO proper shutdown procedure; wait for acks?, kick all characters, ... [FlavoJS]
 	for( int id = 0; id < ARRAYLENGTH(map_server); ++id )

--- a/src/common/core.cpp
+++ b/src/common/core.cpp
@@ -429,6 +429,9 @@ int Core::start( int argc, char **argv ){
 #endif // Pandas_Setup_Console_Output_Codepage
 
 #ifdef Pandas_Google_Breakpad
+#ifndef MINICORE
+	signals_init();
+#endif // MINICORE
 	breakpad_initialize();
 #endif // Pandas_Google_Breakpad
 
@@ -466,11 +469,9 @@ int Core::start( int argc, char **argv ){
 #ifndef MINICORE
 	Sql_Init();
 	db_init();
-#if (!defined(Pandas_Google_Breakpad) || defined(_WIN32))
-	// 若在 Linux 环境下, Breakpad 会接管一部分信号以便进行错误处理
-	// 此处我们不需要再自己进行信号接管了, 否则当程序崩溃的时候 Breakpad 无法生成转储文件
+#ifndef Pandas_Google_Breakpad
 	signals_init();
-#endif // (defined(Pandas_Google_Breakpad) && !defined(_WIN32))
+#endif // Pandas_Google_Breakpad
 	do_init_database();
 #ifdef _WIN32
 	cevents_init();

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1309,6 +1309,9 @@
 
 	// 优化 map-server-generator 的输出信息 [Sola丶小克]
 	#define Pandas_UserExperience_MapServerGenerator_Output
+
+	// 在 Linux 平台上使用 Ctrl+C 输出 ^C 符号之后换一行 [Sola丶小克]
+	#define Pandas_UserExperience_Linux_Ctrl_C_WarpLine
 #endif // Pandas_UserExperience
 
 // ============================================================================

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1311,7 +1311,9 @@
 	#define Pandas_UserExperience_MapServerGenerator_Output
 
 	// 在 Linux 平台上使用 Ctrl+C 输出 ^C 符号之后换一行 [Sola丶小克]
-	#define Pandas_UserExperience_Linux_Ctrl_C_WarpLine
+	#ifndef _WIN32
+		#define Pandas_UserExperience_Linux_Ctrl_C_WarpLine
+	#endif // _WIN32
 #endif // Pandas_UserExperience
 
 // ============================================================================

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -946,6 +946,9 @@ void LoginServer::finalize(){
 }
 
 void LoginServer::handle_shutdown(){
+#ifdef Pandas_UserExperience_Linux_Ctrl_C_WarpLine
+	printf("\n");
+#endif // Pandas_UserExperience_Linux_Ctrl_C_WarpLine
 	ShowStatus("Shutting down...\n");
 	// TODO proper shutdown procedure; kick all characters, wait for acks, ...  [FlavioJS]
 	do_shutdown_loginchrif();

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -6238,6 +6238,9 @@ int mapgenerator_get_options(int argc, char** argv) {
 
 /// Called when a terminate signal is received.
 void MapServer::handle_shutdown(){
+#ifdef Pandas_UserExperience_Linux_Ctrl_C_WarpLine
+	printf("\n");
+#endif // Pandas_UserExperience_Linux_Ctrl_C_WarpLine
 	ShowStatus("Shutting down...\n");
 
 #ifdef Pandas_Crashfix_Prevent_NullPointer

--- a/src/web/web.cpp
+++ b/src/web/web.cpp
@@ -418,6 +418,9 @@ int web_sql_close(void)
  *  dealloc..., function called at exit of the web-server
  */
 void WebServer::finalize(){
+#ifdef Pandas_UserExperience_Linux_Ctrl_C_WarpLine
+	printf("\n");
+#endif // Pandas_UserExperience_Linux_Ctrl_C_WarpLine
 	ShowStatus("Terminating...\n");
 #ifdef WEB_SERVER_ENABLE
 	http_server->stop();


### PR DESCRIPTION
- 之前对接 breakpad 的时候信号处理不正确
  - 导致在 Linux 运行熊猫后使用 Ctrl + C 会直接终止程序（而不会友好的退出程序）
- 在 Linux 终端使用 Ctrl + C 会在终端输出 ^C 符号，在后面换一行（看着顺眼）