### PR TITLE
对 C++17 以及更新的标准中禁用 register 关键字

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1278,6 +1278,13 @@
 // ============================================================================
 
 #ifdef Pandas_UserExperience
+	// 对 C++17 及更新的标准中禁用 register 关键字 [Sola丶小克]
+	// 因为 register 关键字在 C++17 中已被废弃, 且在 C++20 中已被移除
+	// 详见: https://en.cppreference.com/w/cpp/keyword/register
+	#if __cplusplus <= 201703L
+		#define Pandas_UserExperience_Disable_Register_Keyword
+	#endif // __cplusplus >= 201703L
+
 	// 优化使用 @version 指令的回显信息 [Sola丶小克]
 	#define Pandas_UserExperience_AtCommand_Version
 

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -12,6 +12,16 @@
 
 #define Pandas
 
+#if defined(_MSVC_LANG) 
+	#if _MSVC_LANG >= 201703L
+		#define __STDCPP17_AND_NEWER
+	#endif // _MSVC_LANG >= 201703L
+#elif defined(__cplusplus)
+	#if __cplusplus >= 201703L
+		#define __STDCPP17_AND_NEWER
+	#endif // __cplusplus >= 201703L
+#endif
+
 #ifdef Pandas
 	#define Pandas_Basic
 	#define Pandas_DatabaseIncrease
@@ -1281,9 +1291,9 @@
 	// 对 C++17 及更新的标准中禁用 register 关键字 [Sola丶小克]
 	// 因为 register 关键字在 C++17 中已被废弃, 且在 C++20 中已被移除
 	// 详见: https://en.cppreference.com/w/cpp/keyword/register
-	#if __cplusplus >= 201703L
+	#ifdef __STDCPP17_AND_NEWER
 		#define Pandas_UserExperience_Disable_Register_Keyword
-	#endif // __cplusplus >= 201703L
+	#endif // __STDCPP17_AND_NEWER
 
 	// 优化使用 @version 指令的回显信息 [Sola丶小克]
 	#define Pandas_UserExperience_AtCommand_Version

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1281,7 +1281,7 @@
 	// 对 C++17 及更新的标准中禁用 register 关键字 [Sola丶小克]
 	// 因为 register 关键字在 C++17 中已被废弃, 且在 C++20 中已被移除
 	// 详见: https://en.cppreference.com/w/cpp/keyword/register
-	#if __cplusplus <= 201703L
+	#if __cplusplus >= 201703L
 		#define Pandas_UserExperience_Disable_Register_Keyword
 	#endif // __cplusplus >= 201703L
 

--- a/src/map/navi.cpp
+++ b/src/map/navi.cpp
@@ -154,7 +154,11 @@ static int add_path(struct node_heap *heap, int16 x, int16 y, int g_cost, struct
  * Note: uses global g_open_set, therefore this method can't be called in parallel or recursivly.
  *------------------------------------------*/
 bool navi_path_search(struct navi_walkpath_data *wpd, const struct navi_pos *from, const struct navi_pos *dest, cell_chk cell) {
+#ifndef Pandas_UserExperience_Disable_Register_Keyword
 	register int i, x, y, dx = 0, dy = 0;
+#else
+	int i, x, y, dx = 0, dy = 0;
+#endif // Pandas_UserExperience_Disable_Register_Keyword
 	struct map_data *mapdata = map_getmapdata(from->m);
 	struct navi_walkpath_data s_wpd;
 

--- a/src/map/path.cpp
+++ b/src/map/path.cpp
@@ -270,7 +270,11 @@ static int add_path(struct node_heap *heap, struct path_node *tp, int16 x, int16
  *------------------------------------------*/
 bool path_search(struct walkpath_data *wpd, int16 m, int16 x0, int16 y0, int16 x1, int16 y1, int flag, cell_chk cell)
 {
+#ifndef Pandas_UserExperience_Disable_Register_Keyword
 	register int i, x, y, dx = 0, dy = 0;
+#else
+	int i, x, y, dx = 0, dy = 0;
+#endif // Pandas_UserExperience_Disable_Register_Keyword
 	struct map_data *mapdata = map_getmapdata(m);
 	struct walkpath_data s_wpd;
 


### PR DESCRIPTION
因为 register 关键字在 C++17 中已被废弃, 且在 C++20 中已被移除
详见: https://en.cppreference.com/w/cpp/keyword/register

## 验证方法

- 使用 visual studio 编译的时候不再提示关于 register 关键字的警告
- 在 unix 环境下使用 gnu 或 clang 编译器不再提示关于 register 关键字的警告