### PR TITLE
修正计算偷窃概率时公式的计算结果可能出现 "回绕" 的情况

### DIFF
--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -1026,6 +1026,13 @@
 	// 修正 script_cleararray_pc 无法清空单元素数组的问题 [Sola丶小克]
 	// 特别感谢 "最美的Secret" 指出此问题
 	#define Pandas_Fix_ClearArray_The_First_Element_Is_Ignored
+	
+	// 修正计算偷窃概率时公式的计算结果可能出现 "回绕" 的情况 [Sola丶小克]
+	// 只要 sd_status->dex 和 md_status->dex 的类型是无符号数值并且两者相减出现负数,
+	// 那么最终计算出来的概率值因为出现 "回绕" 而变得很大, 结果等于偷窃必定成功.
+	//
+	// 特别感谢 "最美的Secret" 指出此问题
+	#define Pandas_Fix_StealItem_Formula_Overflow
 #endif // Pandas_Bugfix
 
 // ============================================================================

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7194,7 +7194,11 @@ bool pc_steal_item(map_session_data *sd,struct block_list *bl, uint16 skill_lv)
 	}
 
 	// base skill success chance (percentual)
+#ifndef Pandas_Fix_StealItem_Formula_Overflow
 	rate = (sd_status->dex - md_status->dex)/2 + skill_lv*6 + 4;
+#else
+	rate = (static_cast<double>(sd_status->dex) - static_cast<double>(md_status->dex)) / 2 + skill_lv * 6 + 4;
+#endif // Pandas_Fix_StealItem_Formula_Overflow
 	rate += sd->bonus.add_steal_rate;
 
 	if( rate < 1


### PR DESCRIPTION
### 测试方法
- 创造一个 dex 小于 8 的盗贼角色
- 去偷“疯兔”
- 在 rate 所在位置下断点，查看其值

### 备注
- 专业版不存在此问题