### PR TITLE
追加Aegis的0偷BUG模拟

### DIFF
--- a/conf/battle/pandas.conf
+++ b/conf/battle/pandas.conf
@@ -493,4 +493,12 @@ mob_default_damagemotion: 0
 // 默认值为: yes
 mob_setunitdata_persistence: yes
 
+//是否开启0偷？
+//模拟Aegis服早期的著名BUG：0偷效果
+//当盗贼技能偷窃的成功率恰好为0时，有极小的几率能偷窃成功，
+//此时偷窃到的物品几率分布是一个相等的平均值，
+//如果偷窃到的物品指向一个不存在(物品id为0)的物品时，会获得苹果。
+//0偷的成功几率(最大10000 = 100%)，0 关闭
+steal_special: 0
+
 // PYHELP - BATTLECONFIG - INSERT POINT - <Section 4>

--- a/src/config/pandas.hpp
+++ b/src/config/pandas.hpp
@@ -372,6 +372,8 @@
 	// 是否启用 mob_setunitdata_persistence 配置选项及其功能 [Sola丶小克]
 	// 此选项用于控制是否高优先级持久化保存 setunitdata 对魔物的设置
 	#define Pandas_BattleConfig_Mob_SetUnitData_Persistence
+	// 是否开启0偷及设置几率(当偷窃几率正好为0时的特殊几率)
+	#define Pandas_BattleConfig_Steal_Special
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 1>
 #endif // Pandas_BattleConfigure
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11083,6 +11083,9 @@ static const struct _battle_data {
 #ifdef Pandas_BattleConfig_Mob_SetUnitData_Persistence
 	{ "mob_setunitdata_persistence",        &battle_config.mob_setunitdata_persistence,     1,      0,      1,              },
 #endif // Pandas_BattleConfig_Mob_SetUnitData_Persistence
+#ifdef Pandas_BattleConfig_Steal_Special
+	{ "steal_special",        &battle_config.steal_special,     0,      0,      10000,              },
+#endif // Pandas_BattleConfig_Steal_Special
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 3>
 #include <custom/battle_config_init.inc>
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -820,6 +820,9 @@ struct Battle_Config
 #ifdef Pandas_BattleConfig_Mob_SetUnitData_Persistence
 	int mob_setunitdata_persistence;		// 是否高优先级持久化保存 setunitdata 对魔物的设置
 #endif // Pandas_BattleConfig_Mob_SetUnitData_Persistence
+#ifdef Pandas_BattleConfig_Steal_Special
+	int steal_special;		// 开启0偷及设置几率
+#endif // Pandas_BattleConfig_Mob_SetUnitData_Persistence
 	// PYHELP - BATTLECONFIG - INSERT POINT - <Section 2>
 #include <custom/battle_config_struct.inc>
 };


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
模拟Aegis复兴前著名的0偷BUG
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
* 当盗贼技能“偷窃”的成功率恰好为0的时候，将进入0偷的特殊技能模式。
* 技能将以设置好的几率偷窃到物品(即使正常的几率为0)，且各物品的获得
* 几率将不遵循物品的掉落几率而平均化。这将使得稀有物品的获得几率增加。
* 通过battle的pandas.conf设置0偷是否开启以及设置成功几率
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
