### PR TITLE
修正 login 脚本指令返回值不正确的问题 (感谢 "差记性的小北" 反馈)

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -31986,31 +31986,33 @@ BUILDIN_FUNC(disable_batrec) {
  * 作者: Sola丶小克
  * -----------------------------------------------------------*/
 BUILDIN_FUNC(login) {
-	script_pushint(st, 0);
-
 	uint32 charid = 0;
 	charid = script_getnum(st, 2);
 
 	int sit = 0;
 	if (!script_get_optnum(st, 3, "Sitdown or not", sit, true, 0)) {
+		script_pushint(st, 0);
 		return SCRIPT_CMD_FAILURE;
 	}
 	sit = cap_value(sit, 0, 1);
 
 	int body_dir = DIR_SOUTH;
 	if (!script_get_optnum(st, 4, "Body Direction", body_dir, true, DIR_SOUTH)) {
+		script_pushint(st, 0);
 		return SCRIPT_CMD_FAILURE;
 	}
 	body_dir = cap_value(body_dir, 0, 7);
 
 	int head_dir = 0;
 	if (!script_get_optnum(st, 5, "Head Direction", head_dir, true, 0)) {
+		script_pushint(st, 0);
 		return SCRIPT_CMD_FAILURE;
 	}
 	head_dir = cap_value(head_dir, 0, 2);
 
 	int mode = SUSPEND_MODE_NONE;
 	if (!script_get_optnum(st, 6, "Login Mode", mode, true, SUSPEND_MODE_NORMAL)) {
+		script_pushint(st, 0);
 		return SCRIPT_CMD_FAILURE;
 	}
 	if (!suspend_mode_valid(mode)) {
@@ -32019,6 +32021,9 @@ BUILDIN_FUNC(login) {
 
 	if (suspend_recall(charid, (e_suspend_mode)mode, body_dir, head_dir, sit)) {
 		script_pushint(st, 1);
+	}
+	else {
+		script_pushint(st, 0);
 	}
 
 	return SCRIPT_CMD_SUCCESS;


### PR DESCRIPTION
### 问题描述
使用 login 指令成功拉起一个角色之后，脚本指令的返回值是 0

### 预期结果
成功拉起角色的话，返回值应该是 1 才对

### 问题分析
脚本函数处理代码中，提前使用 pushint 压入一个默认值，并在后续流程中根据需要 pushint 其他值这种做法并不能被支持。换而言之，在所有可能得代码分支中，只能出现一次 pushint，即便出现多次程序也只认第一次
